### PR TITLE
Simple Makefile target for generating a SSH config file with the fleet hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,10 @@ install-provisioner:
 init-terraform:
 	terraform init -upgrade=true
 
-SSH_CONFIG_DIR := ~/.ssh/config.d
-SSH_CONFIG_FILE := infra-nimbus
-SSH_USERNAME := $$(whoami)
-
-ssh-config:
-	SSH_CONFIG_DIR=$(SSH_CONFIG_DIR) \
-	SSH_CONFIG_FILE=$(SSH_CONFIG_FILE) \
-	SSH_USERNAME=$(SSH_USERNAME) \
-	bash scripts/create-ssh-config.sh
+ssh-config: export SSH_CONFIG_DIR := ~/.ssh/config.d
+ssh-config: export SSH_CONFIG_FILE := infra-nimbus
+ssh-config: export SSH_USERNAME := $$(whoami)
+	scripts/create-ssh-config.sh
 
 secrets:
 	@echo "Saving Consul certificates: ansible/files/consul*"

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,22 @@ install-provisioner:
 init-terraform:
 	terraform init -upgrade=true
 
+SSH_CONFIG_DIR := ~/.ssh/config.d
+SSH_CONFIG_FILE := infra-nimbus
+SSH_USERNAME := $$(whoami)
+
+ssh-config:
+	SSH_CONFIG_DIR=$(SSH_CONFIG_DIR) \
+	SSH_CONFIG_FILE=$(SSH_CONFIG_FILE) \
+	SSH_USERNAME=$(SSH_USERNAME) \
+	bash scripts/create-ssh-config.sh
+
 secrets:
 	@echo "Saving Consul certificates: ansible/files/consul*"
 	pass services/consul/ca-crt > ansible/files/consul-ca.crt
 	pass services/consul/ca-key > ansible/files/consul-ca.key
 	pass services/consul/client-crt > ansible/files/consul-client.crt
 	pass services/consul/client-key > ansible/files/consul-client.key
-
 
 cleanup:
 	rm -r $(PLUGIN_DIR)/$(ARCHIVE)

--- a/scripts/create-ssh-config.sh
+++ b/scripts/create-ssh-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/usr/env bash
 
 set -e
 cd $(dirname "$0")

--- a/scripts/create-ssh-config.sh
+++ b/scripts/create-ssh-config.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+cd $(dirname "$0")
+
+if [[ "${SSH_CONFIG_DIR}" == "" ]]; then
+  echo Please specify the SSH_CONFIG_DIR environment variable
+  exit 1
+fi
+
+if [[ "${SSH_CONFIG_FILE}" == "" ]]; then
+  echo Please specify the SSH_CONFIG_FILE environment variable
+  exit 1
+fi
+
+INFRA_NIMBUS_SSH_CONFIG="${SSH_CONFIG_DIR}/${SSH_CONFIG_FILE}"
+: ${SSH_USERNAME:=$(whoami)}
+
+mkdir -p "${SSH_CONFIG_DIR}" && chmod 700 "${SSH_CONFIG_DIR}"
+rm -f "${INFRA_NIMBUS_SSH_CONFIG}"
+
+for host in $(ansible all -i ../ansible/inventory/test --list-hosts | grep -v 'hosts')
+do
+	cat << EOF >> "${INFRA_NIMBUS_SSH_CONFIG}"
+Host nimbus-$host
+  Hostname $host.statusim.net
+  User ${SSH_USERNAME}
+
+EOF
+done
+
+echo "Successfully written '${INFRA_NIMBUS_SSH_CONFIG}'"


### PR DESCRIPTION
`make ssh-config` will generate a file `~/.ssh/config.d/infra-numbus` with all
hostnames from the Ansible inventory. You can `Include` this file from your
main config file and re-generate it at will at any time. Having such a config
file makes it easier to ssh into any host on the fleet by taking advantage of
the built-in ssh hostname autocompletion in your shell.

The names of the entries were chosen in a way such that typing:

```
ssh nimbus<tab>goerli<tab>
```

... produces the expected result.