### PR TITLE
beacon-node-builds: support core dumps

### DIFF
--- a/ansible/host_vars/master-small-01.aws-eu-central-1a.nimbus.pyrmont.yml
+++ b/ansible/host_vars/master-small-01.aws-eu-central-1a.nimbus.pyrmont.yml
@@ -6,14 +6,14 @@ beacon_node_builds_docker_hub_token: '{{lookup("passwordstore", "cloud/DockerHub
 # The -small suffix is because of native compilation
 beacon_node_builds_branches:
   - name: 'devel-small'
-    branch: 'devel'
+    version: 'devel'
     targets: ['nimbus_beacon_node', 'nimbus_signing_process']
     frequency: '*-*-* 10:00:00'
   - name: 'master-small'
-    branch: 'master'
+    version: 'master'
     targets: ['nimbus_beacon_node', 'nimbus_signing_process']
     frequency: '*-*-* 02:00:00'
   - name: 'libp2p-small'
-    branch: 'nim-libp2p-auto-bump'
+    version: 'nim-libp2p-auto-bump'
     targets: ['nimbus_beacon_node', 'nimbus_signing_process']
     frequency: '*-*-* 18:00:00'

--- a/ansible/inventory/test
+++ b/ansible/inventory/test
@@ -46,6 +46,10 @@ goerli-01.aws-eu-central-1a.nimbus.geth
 [nimbus-geth-mainnet]
 mainnet-01.aws-eu-central-1a.nimbus.geth
 
+[nimbus-master]
+master-small-01.aws-eu-central-1a.nimbus.pyrmont
+master-large-01.aws-eu-central-1a.nimbus.pyrmont
+
 [nimbus-mainnet-small]
 master-small-01.aws-eu-central-1a.nimbus.mainnet
 master-small-02.aws-eu-central-1a.nimbus.mainnet

--- a/ansible/roles/beacon-node-builds/README.md
+++ b/ansible/roles/beacon-node-builds/README.md
@@ -9,7 +9,7 @@ The minimal configuration would look something like:
 # Branch to build and frequency
 beacon_node_builds_branches:
   - name: 'xyz'
-    branch: 'feature/xyz'
+    version: 'feature/xyz'
     targets: ['nimbus_beacon_node', 'nimbus_signing_process']
     frequency: '*-*-* 02:00:00'
 

--- a/ansible/roles/beacon-node-builds/templates/build.sh.j2
+++ b/ansible/roles/beacon-node-builds/templates/build.sh.j2
@@ -17,7 +17,7 @@ pushd repo
 COMMIT_BEFORE=$(git rev-parse --short=8 HEAD)
 # We cannot use "git pull" in here, because history may be changed upstream
 git fetch
-git reset --hard origin/{{ item.branch }}
+git reset --hard origin/{{ item.version }}
 COMMIT_AFTER=$(git rev-parse --short=8 HEAD)
 
 if [[ "$1" == "--force" ]]; then
@@ -32,7 +32,12 @@ NICE="nice -n 19 ionice -c2 -n7"
 
 ${NICE} make -j1 update
 ${NICE} make -j1 {{ item.targets | join(" ") }} \
-    LOG_LEVEL="TRACE" NIMFLAGS="-d:insecure -d:testnet_servers_image"
+    LOG_LEVEL="TRACE" NIMFLAGS="-d:insecure -d:testnet_servers_image -d:noSignalHandler"
+
+# Keep some copies of the resulting binaries, to be used for debugging in case of core dumps
+cp -a build/nimbus_beacon_node "build/nimbus_beacon_node_{{ item.name }}_$(date +%F_%H-%M-%S)"
+# Delete copies that are older than 7 days
+find build -name 'nimbus_beacon_node_*' -mtime +7 -exec rm '{}' \+
 
 popd
 


### PR DESCRIPTION
- build with "-d:noSignalHandler" in NIMFLAGS
- keep binary copies for a week, so we can use them with core dumps on target hosts
- finish replacing "item.branch" with "item.version"
- manually add a [nimbus-master] section to "ansible/inventory/test" (FIXME: this should be automatically generated)