### PR TITLE
upgrade tf pass provider to 2.0.0

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -9,3 +9,6 @@ provider "cloudflare" {
   api_key    = data.pass_password.cloudflare_token.password
   account_id = data.pass_password.cloudflare_account.password
 }
+
+# Uses PASSWORD_STORE_DIR environment variable
+provider "pass" {}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,6 +1,3 @@
-# Uses PASSWORD_STORE_DIR environment variable
-provider "pass" { refresh_store = false }
-
 /* Token for interacting with Cloudflare API. */
 data "pass_password" "cloudflare_token" {
   path = "cloud/Cloudflare/token"

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     pass = {
       source  = "camptocamp/pass"
-      version = " = 1.4.0"
+      version = " = 2.0.0"
     }
   }
 }


### PR DESCRIPTION
I was experiencing errors when using the pass provider:

```
Error: rpc error: code = Unavailable desc = transport is closing
```

With lot of errors in the log:

```
2021-03-29T12:56:28.109+0800 [WARN]  plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unimplemented desc = unknown service plugin.GRPCStdio"
2021-03-29T12:56:28.265+0800 [WARN]  plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
```

Upgrading to the latest version of the pass provider fixes the problem for me.

Terraform 0.14.4
