### PR TITLE
Add support for installing RocketPool nodes

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -34,6 +34,12 @@ beacon_node_cont_name: 'beacon-node-{{ beacon_node_network }}-{{ beacon_node_con
 beacon_node_log_level: DEBUG
 beacon_node_timer_rebuild: true
 
+# RocketPool settings
+# We use non-standard ports to avoid conflicts with out fleet nodes
+rocketpool_smart_node_eth2_libp2p_port: 10001
+rocketpool_smart_node_eth2_discovery_port: 10001
+rocketpool_smart_node_eth2_graffiti: 'Nimbus on RocketPool'
+
 # ports
 beacon_node_rpc_port: '11000'
 beacon_node_metrics_port : '9300'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,6 +31,10 @@
   src: git@github.com:status-im/infra-role-beacon-node.git
   scm: git
 
+- name: infra-role-rocketpool-smart-node
+  src: git@github.com:status-im/infra-role-rocketpool-smart-node.git
+  scm: git
+
 - name: infra-role-eth2-testnet-site
   src: git@github.com:status-im/infra-role-eth2-testnet-site.git
   scm: git

--- a/ansible/rocketpool.yml
+++ b/ansible/rocketpool.yml
@@ -1,0 +1,20 @@
+---
+- name: Configure RocketPool nodes
+  become: true
+  hosts:
+    - testing-small-03.aws-eu-central-1a.nimbus.pyrmont
+    - testing-small-04.aws-eu-central-1a.nimbus.pyrmont
+  pre_tasks:
+    - name: Discover Goerli Geth WebSocket endpoint
+      tags: [ infra-role-rocketpool-smart-node, rocketpool ]
+      uri:
+        url: '{{ consul_catalog_url }}/service/nimbus-goerli-node-ws'
+      register: geth_service
+
+    - name: Extract Goerli Geth WebSocket URL
+      tags: [ infra-role-rocketpool-smart-node, rocketpool ]
+      set_fact:
+        rocketpool_smart_node_web3_url: 'ws://{{ geth_service.json[0].ServiceAddress }}:{{ geth_service.json[0].ServicePort }}'
+  roles:
+    - { role: infra-role-rocketpool-smart-node, tags: rocketpool }
+


### PR DESCRIPTION
I've used this to install RocketPool smart nodes on the `testing-small-03` and `testing-small-04` Pyrmont hosts which are currently used as bootstrap nodes (having lower CPU usage). The RockerPool instances will each run around 25 validators, so hopefully the small servers will be able to handle the load.