### PR TITLE
Use the default slashing DB kind (v2)

### DIFF
--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -1,8 +1,2 @@
 ---
 beacon_node_network: 'prater'
-
-# We are running v2 on all hosts prior to the official release in order
-# to reduce the I/O load on all servers. On the large servers where we
-# have enough capacity, we're running the `both` mode that checks that
-# the new slashing DB logic behaves precisely as the old one.
-beacon_node_slashing_db_kind: '{{ (hostname is search("large")) | ternary("both", "v2") }}'

--- a/ansible/group_vars/nimbus.pyrmont.yml
+++ b/ansible/group_vars/nimbus.pyrmont.yml
@@ -1,6 +1,0 @@
----
-# We are running v2 on all hosts prior to the official release in order
-# to reduce the I/O load on all servers. On the large servers where we
-# have enough capacity, we're running the `both` mode that checks that
-# the new slashing DB logic behaves precisely as the old one.
-beacon_node_slashing_db_kind: '{{ (hostname is search("large")) | ternary("both", "v2") }}'


### PR DESCRIPTION
The default `v2` mode is now sufficiently tested, so we don't need to run more A/B testing experiments.