### PR TITLE
add terraform hetzner dummy module

### DIFF
--- a/modules/hetzner/README.md
+++ b/modules/hetzner/README.md
@@ -1,0 +1,5 @@
+# Description
+
+This isn't a real Hetzner cloud provider module for Terrafom.
+
+This is just a dummy module which creates the Ansible inventory hosts in order to make the Hetzner hosts appear the same way all the other hosts created by Terraform do.

--- a/modules/hetzner/main.tf
+++ b/modules/hetzner/main.tf
@@ -1,0 +1,48 @@
+/*************************************************
+ * WARNING!
+ * This is not a Terraform provider for Hetzner.
+ * I'm just creating the inventory entries
+ * the same way I do it for other hosts so
+ * Ansible can use them during provisioning.
+ *************************************************/
+
+/* DERIVED --------------------------------------*/
+
+locals {
+  stage = var.stage != "" ? var.stage : terraform.workspace
+  tokens = split(".", local.stage)
+  dc     = "${var.provider_name}-${var.region}"
+
+  # map of ip => hostname
+  hostnames = { for i, ip in var.ips :
+    ip => "${var.name}-${format("%02d", i + 1)}.${local.dc}.${var.env}.${local.stage}"
+  }
+}
+
+/* RESOURCES ------------------------------------*/
+
+resource "ansible_host" "host" {
+  for_each           = local.hostnames
+  inventory_hostname = each.value
+  groups             = [var.group, local.dc]
+  vars = {
+    ansible_host     = each.key
+    ansible_ssh_user = var.ssh_user
+    hostname         = each.value
+    region           = var.region
+    dns_domain       = var.domain
+    dns_entry        = "${each.value}.${var.domain}"
+    data_center      = local.dc
+    stage            = local.stage
+    env              = var.env
+  }
+}
+
+resource "cloudflare_record" "host" {
+  for_each = local.hostnames
+  zone_id  = var.cf_zone_id
+  name     = each.value // hostname
+  value    = each.key   // ip
+  type     = "A"
+  ttl      = 3600
+}

--- a/modules/hetzner/variables.tf
+++ b/modules/hetzner/variables.tf
@@ -1,0 +1,63 @@
+/* SCALING --------------------------------------*/
+
+variable "ips" {
+  description = "Static list of IPs used by the hosts."
+  type        = list(string)
+}
+
+variable "region" {
+  description = "Region in which the host reside."
+  type        = string
+  default     = "eu-hel1"
+}
+
+variable "provider_name" {
+  description = "Short name of provider being used."
+  type        = string
+  default     = "he"
+}
+
+/* SECURITY --------------------------------------*/
+
+variable "ssh_user" {
+  description = "Default user for SSH access."
+  type        = string
+  default     = "root"
+}
+
+/* CONFIG ----------------------------------------*/
+
+variable "name" {
+  description = "Name for hosts. To be used in the DNS entry."
+  type        = string
+}
+
+variable "env" {
+  description = "Environment for these hosts, affects DNS entries."
+  type        = string
+}
+
+variable "stage" {
+  description = "Name of stage, like prod, dev, or staging."
+  type        = string
+  default     = ""
+}
+
+variable "group" {
+  description = "Ansible group to assign hosts to."
+  type        = string
+}
+
+variable "domain" {
+  description = "DNS Domain to update"
+  type        = string
+}
+
+/* DNS ------------------------------------------*/
+
+/* We default to: statusim.net */
+variable "cf_zone_id" {
+  description = "ID of CloudFlare zone for host record."
+  type        = string
+  default     = "14660d10344c9898521c4ba49789f563"
+}

--- a/modules/hetzner/versions.tf
+++ b/modules/hetzner/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 0.14.4"
+  required_providers {
+    ansible = {
+      source  = "nbering/ansible"
+      version = " = 1.0.4"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = " = 2.10.1"
+    }
+  }
+}


### PR DESCRIPTION
This is a dummy module for our dedicated hetzner server. We do this to keep our ansible inventory consistent with other modules.

I've tested this module by creating a `stable-hetzner-01.he-eu-hel1.nimbus.prater` host and running our ansible bootstrap script on it. Everything worked and we can continue with the server setup. I'm going to reset/delete the test-server and we can discuss next what we want to run on the server.