### PR TITLE
Add hetzner dedicated server

### DIFF
--- a/ansible/group_vars/nimbus-mainnet-metal.yml
+++ b/ansible/group_vars/nimbus-mainnet-metal.yml
@@ -1,7 +1,6 @@
 ---
 beacon_node_network: 'mainnet'
 beacon_node_cont_tag: 'stable-metal-01'
-beacon_node_web3_urls: ['ws://mainnet-01.aws-eu-central-1a.nimbus.geth.tinc:8546']
 
 # WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
 #beacon_node_netkey: '{{lookup("passwordstore","services/Nimbus/netkey/"+hostname)}}'

--- a/ansible/group_vars/nimbus-mainnet-metal.yml
+++ b/ansible/group_vars/nimbus-mainnet-metal.yml
@@ -1,0 +1,9 @@
+---
+beacon_node_network: 'mainnet'
+beacon_node_cont_tag: 'stable-metal-01'
+
+# WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
+#beacon_node_netkey: '{{lookup("passwordstore","services/Nimbus/netkey/"+hostname)}}'
+
+# Bootnodes should subscribe to all subnets
+#beacon_node_subscribe_all: true

--- a/ansible/group_vars/nimbus-mainnet-metal.yml
+++ b/ansible/group_vars/nimbus-mainnet-metal.yml
@@ -1,9 +1,10 @@
 ---
 beacon_node_network: 'mainnet'
 beacon_node_cont_tag: 'stable-metal-01'
+beacon_node_web3_urls: ['ws://mainnet-01.aws-eu-central-1a.nimbus.geth.tinc:8546']
 
 # WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
 #beacon_node_netkey: '{{lookup("passwordstore","services/Nimbus/netkey/"+hostname)}}'
 
 # Bootnodes should subscribe to all subnets
-#beacon_node_subscribe_all: true
+beacon_node_subscribe_all: true

--- a/ansible/host_vars/stable-metal-01.he-eu-hel1.nimbus.mainnet.yml
+++ b/ansible/host_vars/stable-metal-01.he-eu-hel1.nimbus.mainnet.yml
@@ -1,0 +1,11 @@
+---
+# Docker image builds
+beacon_node_builds_docker_hub_user: '{{lookup("passwordstore", "cloud/DockerHub/user")}}'
+beacon_node_builds_docker_hub_token: '{{lookup("passwordstore", "cloud/DockerHub/token")}}'
+
+# The -small suffix is because of native compilation
+beacon_node_builds_branches:
+  - name: 'stable-metal-01'
+    version: 'stable'
+    targets: ['nimbus_beacon_node', 'nimbus_signing_process']
+    frequency: '*-*-* 12:00:00'

--- a/ansible/inventory/test
+++ b/ansible/inventory/test
@@ -14,6 +14,7 @@ stable-large-02.aws-eu-central-1a.nimbus.prater hostname=stable-large-02.aws-eu-
 stable-large-03.aws-eu-central-1a.nimbus.prater hostname=stable-large-03.aws-eu-central-1a.nimbus.prater ansible_host=3.64.72.159 env=nimbus stage=prater data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-large-03.aws-eu-central-1a.nimbus.prater.statusim.net
 stable-large-04.aws-eu-central-1a.nimbus.prater hostname=stable-large-04.aws-eu-central-1a.nimbus.prater ansible_host=3.65.240.81 env=nimbus stage=prater data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-large-04.aws-eu-central-1a.nimbus.prater.statusim.net
 stable-large-05.aws-eu-central-1a.nimbus.prater hostname=stable-large-05.aws-eu-central-1a.nimbus.prater ansible_host=18.158.95.252 env=nimbus stage=prater data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-large-05.aws-eu-central-1a.nimbus.prater.statusim.net
+stable-metal-01.he-eu-hel1.nimbus.mainnet hostname=stable-metal-01.he-eu-hel1.nimbus.mainnet ansible_host=65.21.73.183 env=nimbus stage=mainnet data_center=he-eu-hel1 region=eu-hel1 dns_entry=stable-metal-01.he-eu-hel1.nimbus.mainnet.statusim.net
 stable-small-01.aws-eu-central-1a.nimbus.mainnet hostname=stable-small-01.aws-eu-central-1a.nimbus.mainnet ansible_host=3.120.104.18 env=nimbus stage=mainnet data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-small-01.aws-eu-central-1a.nimbus.mainnet.statusim.net
 stable-small-01.aws-eu-central-1a.nimbus.pyrmont hostname=stable-small-01.aws-eu-central-1a.nimbus.pyrmont ansible_host=3.64.67.28 env=nimbus stage=pyrmont data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-small-01.aws-eu-central-1a.nimbus.pyrmont.statusim.net
 stable-small-02.aws-eu-central-1a.nimbus.mainnet hostname=stable-small-02.aws-eu-central-1a.nimbus.mainnet ansible_host=3.64.117.223 env=nimbus stage=mainnet data_center=aws-eu-central-1a region=eu-central-1a dns_entry=stable-small-02.aws-eu-central-1a.nimbus.mainnet.statusim.net
@@ -87,6 +88,9 @@ unstable-small-04.aws-eu-central-1a.nimbus.pyrmont
 [dash.nimbus]
 node-01.aws-eu-central-1a.dash.nimbus
 
+[he-eu-hel1]
+stable-metal-01.he-eu-hel1.nimbus.mainnet
+
 [log-dash]
 node-01.aws-eu-central-1a.dash.nimbus
 
@@ -105,6 +109,9 @@ goerli-01.aws-eu-central-1a.nimbus.geth
 
 [nimbus-geth-mainnet]
 mainnet-01.aws-eu-central-1a.nimbus.geth
+
+[nimbus-mainnet-metal]
+stable-metal-01.he-eu-hel1.nimbus.mainnet
 
 [nimbus-mainnet-small]
 stable-small-01.aws-eu-central-1a.nimbus.mainnet

--- a/ansible/inventory/test
+++ b/ansible/inventory/test
@@ -174,6 +174,7 @@ goerli-01.aws-eu-central-1a.nimbus.geth
 mainnet-01.aws-eu-central-1a.nimbus.geth
 
 [nimbus.mainnet]
+stable-metal-01.he-eu-hel1.nimbus.mainnet
 stable-small-01.aws-eu-central-1a.nimbus.mainnet
 stable-small-02.aws-eu-central-1a.nimbus.mainnet
 

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -9,6 +9,13 @@
     - local_action: command ./versioncheck.py
       changed_when: false
 
+- name: Configure build nodes
+  become: true
+  hosts:
+    - stable-metal-01.he-eu-hel1.nimbus.mainnet
+  roles:
+    - { role: beacon-node-builds,     tags: beacon-node-builds }
+
 - name: Configure network mainnet bootnodes
   become: true
   hosts: 'nimbus.mainnet'

--- a/mainnet.tf
+++ b/mainnet.tf
@@ -25,3 +25,17 @@ module "nimbus_nodes_mainnet_stable_small" {
   secgroup_id  = module.nimbus_network.secgroup.id
   keypair_name = aws_key_pair.jakubgs.key_name
 }
+
+module "nimbus_nodes_mainnet_stable_hetzner" {
+  source = "./modules/hetzner"
+
+  name   = "stable-metal"
+  env    = "nimbus"
+  stage  = "mainnet"
+  group  = "nimbus-mainnet-metal"
+  domain = var.domain
+
+  ips = [
+    "65.21.73.183"
+  ]
+}

--- a/modules/hetzner/main.tf
+++ b/modules/hetzner/main.tf
@@ -24,7 +24,7 @@ locals {
 resource "ansible_host" "host" {
   for_each           = local.hostnames
   inventory_hostname = each.value
-  groups             = [var.group, local.dc]
+  groups             = [var.group, local.dc, "${var.env}.${local.stage}"]
   vars = {
     ansible_host     = each.key
     hostname         = each.value

--- a/modules/hetzner/main.tf
+++ b/modules/hetzner/main.tf
@@ -27,7 +27,6 @@ resource "ansible_host" "host" {
   groups             = [var.group, local.dc]
   vars = {
     ansible_host     = each.key
-    ansible_ssh_user = var.ssh_user
     hostname         = each.value
     region           = var.region
     dns_domain       = var.domain


### PR DESCRIPTION
This PR adds the hetzner dedicated server mentioned in #52 to the infra.

The server will run stable branch on mainnet.

The builds are set up and work:
https://hub.docker.com/layers/statusteam/nimbus_beacon_node/stable-metal-01/images/sha256-3f38ccf62e519cf4beaeda5c82bcd6bb9887aea325221b6c8da6580632d0ade9?context=explore

However, the problem is that the server is not added to the ansible inventory under `[nimbus.mainnet]`,
which prevents the `infra-role-beacon-node` role to run. I'm looking more into
it.
