### PR TITLE
Scan all DC's for Geth nodes

### DIFF
--- a/ansible/roles/get-geth-web3-urls/tasks/main.yml
+++ b/ansible/roles/get-geth-web3-urls/tasks/main.yml
@@ -1,13 +1,25 @@
 ---
-- name: Discover Goerli Geth WebSocket endpoint
+- name: Find available data centers
   uri:
-    url: '{{ consul_catalog_url }}/service/{{ web3_geth_node_consul_name }}'
-  register: geth_service
+    url: '{{ consul_catalog_url }}/datacenters'
+  register: data_centers
+
+- name: Find available geth websocket services
+  uri:
+    url: '{{ consul_catalog_url }}/service/{{ web3_geth_node_consul_name }}?dc={{ item }}'
+  with_items: '{{ data_centers.json }}'
+  register: geth_ws_services
+
+- name: Extract Geth websocket IP and port
+  set_fact:
+    geth_ws_addresses: |
+      {{ geth_ws_services.results
+      | sum(attribute="json", start=[])
+      | json_query("[].[ServiceAddress, ServicePort]")
+      | map('join', ':')
+      | list }}
 
 - name: Extract Goerli Geth WebSocket URL
   set_fact:
-    beacon_node_web3_urls:
-      # Our Goerli node goes first, and will be used by default.
-      - 'ws://{{ geth_service.json[0].ServiceAddress }}:{{ geth_service.json[0].ServicePort }}'
-      # We want to spread the load, but we want the choice to be deterministic.
-      - '{{ selected_infura_url }}'
+    # our nodes first (will be used by default) then an infura node
+    beacon_node_web3_urls: "{{ geth_ws_addresses + [ selected_infura_url ] }}"


### PR DESCRIPTION
Instead of assuming there is a geth node running in the same datacenter it will scan all data center's for nodes that match the network.

This is necessary for #56 since we don't have a mainnet node running in the hetzner DC and it would take too long to set one up. With this change it will discover the mainnet node in the AWS dc and use it.

