### PR TITLE
Experimental deployment of RocketPool on the Rayonism host

### DIFF
--- a/ansible/group_vars/nimbus-geth-goerli.yml
+++ b/ansible/group_vars/nimbus-geth-goerli.yml
@@ -34,3 +34,5 @@ open_ports_list:
   - { port: '{{ geth_expo_cont_port }}', ipset: 'metrics.hq' }
   - { port: '{{ geth_websocket_port }}', ipset: 'nimbus.pyrmont' }
   - { port: '{{ geth_websocket_port }}', ipset: 'nimbus.prater' }
+  - { port: '{{ geth_websocket_port }}', ipset: 'nimbus.rayonism' }
+  - { port: '{{ geth_rpc_port }}'      , ipset: 'nimbus.rayonism' }

--- a/ansible/group_vars/nimbus.rayonism.yml
+++ b/ansible/group_vars/nimbus.rayonism.yml
@@ -44,3 +44,7 @@ beacon_node_doppelganger_detection: false
 beacon_node_dist_validators_enabled: true
 beacon_node_dist_validators_start: 0
 beacon_node_dist_validators_end: 2400
+
+rocketpool_web3_url: 'http://goerli-01.aws-eu-central-1a.nimbus.geth.wg:8545'
+rocketpool_web3_ws_url: 'ws://goerli-01.aws-eu-central-1a.nimbus.geth.wg:8546'
+

--- a/ansible/prater.yml
+++ b/ansible/prater.yml
@@ -50,6 +50,7 @@
         beacon_node_listening_port: '{{ 9000 + port_offset }}'
         beacon_node_metrics_port:   '{{ 9200 + port_offset }}'
         beacon_node_rest_port:      '{{ 9300 + port_offset }}'
+        beacon_node_rpc_enabled:    true
         beacon_node_rpc_port:       '{{ 9900 + port_offset }}'
         beacon_node_dist_validators_start: '{{ node.start }}'
         beacon_node_dist_validators_end: '{{ node.end }}'

--- a/ansible/pyrmont.yml
+++ b/ansible/pyrmont.yml
@@ -30,6 +30,7 @@
         beacon_node_listening_port: '{{ 9000 + port_offset }}'
         beacon_node_metrics_port:   '{{ 9200 + port_offset }}'
         beacon_node_rest_port:      '{{ 9300 + port_offset }}'
+        beacon_node_rpc_enabled:    true
         beacon_node_rpc_port:       '{{ 9900 + port_offset }}'
         beacon_node_dist_validators_start: '{{ validators_layout[hostname][node.name]["start"] | mandatory }}'
         beacon_node_dist_validators_end: '{{ validators_layout[hostname][node.name]["end"] | mandatory }}'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -46,7 +46,7 @@
 
 - name: infra-role-beacon-node-linux
   src: git@github.com:status-im/infra-role-beacon-node-linux.git
-  version: 9f5295274066ab707320d6bc2d6fb46e8ff5b520
+  version: 172e0000f1bca4eddec77a209b28b954d7e83569
   scm: git
 
 - name: infra-role-beacon-node-windows

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -46,7 +46,7 @@
 
 - name: infra-role-beacon-node-linux
   src: git@github.com:status-im/infra-role-beacon-node-linux.git
-  version: c327a454ce113a7d5c1432029aadaaf39c6ca83c
+  version: 9f5295274066ab707320d6bc2d6fb46e8ff5b520
   scm: git
 
 - name: infra-role-beacon-node-windows
@@ -57,6 +57,11 @@
 - name: infra-role-dist-validators
   src: git@github.com:status-im/infra-role-dist-validators.git
   version: 1ec52b38e36cd1af939317ea51bbd74984986725
+  scm: git
+
+- name: infra-role-rocketpool-smart-node
+  src: git@github.com:status-im/infra-role-rocketpool-smart-node.git
+  version: 4ff40088a29e1c3a332d82cd915812f7c07e5c96
   scm: git
 
 - name: infra-role-winsw

--- a/ansible/rocketpool.yml
+++ b/ansible/rocketpool.yml
@@ -1,0 +1,17 @@
+---
+- name: Verify Ansible versions
+  hosts: all
+  tags: always
+  become: false
+  run_once: true
+  gather_facts: false
+  tasks:
+    - local_action: command ./versioncheck.py
+      changed_when: false
+
+- name: Configure RocketPool node
+  become: true
+  hosts:
+    - nimbus-rayonism-qmerge
+  roles:
+    - { role: infra-role-rocketpool-smart-node, tags: rocketpool }


### PR DESCRIPTION
I've used this to deploy the latest version of the RocketPool smart node to the now obsolete Rayonism host.

The RocketPool setup consist of 3 services:

1) A nimbus beacon node connect to the Prater network and the Goerli Geth instance. The web3 URLs for this must be specified in the variables `rocketpool_web3_url` and `rocketpool_web3_ws_url` of the rocketpool-smart-node role.

2) rocketpool-node - A regular instance of the rocketpool daemon

3) rocketpool-watchtower - A special node performing oracle services within the RocketPool network. Once the deployment is complete, we'll have to carry out some manual operations on the host to install our private oracle credentials.

The services have been configured by following the practices of the following guide:
https://docs.rocketpool.net/guides/node/native.html#creating-service-accounts

Ansible playbook:
https://github.com/status-im/infra-role-rocketpool-smart-node