### PR TITLE
nimbus: mark branches supporting BN light client server

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -30,6 +30,8 @@ beacon_node_dist_validators_enabled: false
 beacon_node_subscribe_all: true
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
+# Light client data
+beacon_node_light_client_data_enabled: '{{ node.branch in ["unstable", "libp2p"] }}'
 # Other
 beacon_node_proposer_boosting_debug: '{{ node.branch == "unstable" }}'
 

--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -42,6 +42,8 @@ beacon_node_dist_validators_end: '{{ node.end | mandatory }}'
 beacon_node_service_user_pass: '{{lookup("bitwarden", "nimbus/windows", field="password")}}'
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
+# Light client data
+beacon_node_light_client_data_enabled: '{{ node.branch in ["unstable", "libp2p"] }}'
 # Other
 beacon_node_proposer_boosting_debug: '{{ node.branch == "unstable" }}'
 

--- a/ansible/group_vars/nimbus.pyrmont.yml
+++ b/ansible/group_vars/nimbus.pyrmont.yml
@@ -27,6 +27,8 @@ beacon_node_dist_validators_start: '{{ node.start | mandatory }}'
 beacon_node_dist_validators_end: '{{ node.end | mandatory }}'
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
+# Light client data
+beacon_node_light_client_data_enabled: '{{ node.branch in ["unstable", "libp2p"] }}'
 # Other
 beacon_node_proposer_boosting_debug: '{{ node.branch == "unstable" }}'
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -46,17 +46,17 @@
 
 - name: infra-role-beacon-node-linux
   src: git@github.com:status-im/infra-role-beacon-node-linux.git
-  version: eb618e976f7e79479cb3da157a2693951f218835
+  version: 15b7b7eec65e596c84a624cd5da98bc2affeadec
   scm: git
 
 - name: infra-role-beacon-node-windows
   src: git@github.com:status-im/infra-role-beacon-node-windows.git
-  version: 8599494a48d0b1f7c3da0d338088e7c895737b80
+  version: eb51f129e13509517207f9763c3522ed5fcba7be
   scm: git
 
 - name: infra-role-beacon-node-macos
   src: git@github.com:status-im/infra-role-beacon-node-macos.git
-  version: dda865b674bb04af8599061586f41b65440c30db
+  version: ea75d54addd7d50c3b06acfc489408e2aaecb920
   scm: git
 
 - name: infra-role-nimbus-eth1


### PR DESCRIPTION
The idea here is to conditionally enable support for the new light client server arguments depending on whether the node is using a repo branch that supports the corresponding launch arguments.

- Linux: https://github.com/status-im/infra-role-beacon-node-linux/pull/7
- macOS: https://github.com/status-im/infra-role-beacon-node-macos/pull/3
- Windows: https://github.com/status-im/infra-role-beacon-node-windows/pull/2
 