### PR TITLE
disable light client data overrides

### DIFF
--- a/ansible/group_vars/nimbus.kiln.yml
+++ b/ansible/group_vars/nimbus.kiln.yml
@@ -44,10 +44,6 @@ beacon_node_validator_monitor_auto: true
 beacon_node_validator_monitor_totals: true
 # Eth1 Sync
 beacon_node_web3_urls: ['ws://{{ hostname }}.wg:{{ geth_websocket_port }}']
-# Light client data
-beacon_node_light_client_data_enabled: true
-beacon_node_light_client_data_serve: true
-beacon_node_light_client_data_import: 'only-new'
 # Validators from nimbus-private repo
 beacon_node_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 beacon_node_dist_validators_start: '{{ node.start | mandatory }}'

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -28,8 +28,6 @@ beacon_node_dist_validators_enabled: false
 beacon_node_subscribe_all: true
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
-# Light client data
-beacon_node_light_client_data_enabled: '{{ node.branch in ["unstable", "libp2p"] }}'
 
 # Purge node DB periodically to test syncing.
 nimbus_db_purge_node_service_name: '{{ beacon_node_service_name }}'

--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -40,10 +40,6 @@ beacon_node_dist_validators_end: '{{ node.end | mandatory }}'
 beacon_node_service_user_pass: '{{lookup("bitwarden", "nimbus/windows", field="password")}}'
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
-# Light client data
-beacon_node_light_client_data_enabled: '{{ node.branch in ["unstable", "libp2p"] }}'
-beacon_node_light_client_data_serve: true
-beacon_node_light_client_data_import: 'only-new'
 
 # Split by hostname for more central location
 nodes_layout:

--- a/ansible/group_vars/nimbus.ropsten.yml
+++ b/ansible/group_vars/nimbus.ropsten.yml
@@ -11,10 +11,6 @@ beacon_node_validator_monitor_totals: true
 # HTTP RPC support is unstable
 beacon_node_web3_urls: '{{ beacon_node_web3_urls_all | reject("match", "^http://") }}'
 beacon_node_extra_flags: ['--terminal-total-difficulty-override=50000000000000000']
-# Light client data
-beacon_node_light_client_data_enabled: true
-beacon_node_light_client_data_serve: true
-beacon_node_light_client_data_import: 'only-new'
 # Validators from nimbus-private repo
 beacon_node_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 beacon_node_dist_validators_start: '{{ node.start | mandatory }}'


### PR DESCRIPTION
On `kiln`, `ropsten`, `prater`, `sepolia`, the BN code applies network
specific defaults `true` / `only-new`. `mainnet`: `false` / `none`.
This means that the overrides here are no longer needed, also avoiding
issues with planned renames of the parameters in the BN implementation.