### PR TITLE
Enable the VC payload builder on linux-06's testing intance

### DIFF
--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -91,6 +91,8 @@ validator_client_build_frequency: 'daily'
 # Ports
 validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
+# MEV Payload Builder
+validator_client_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 # Keymanager
 validator_client_keymanager_enabled: true
 validator_client_keymanager_token: '{{lookup("bitwarden", "nimbus/keymanager", field="token")}}'
@@ -171,6 +173,6 @@ nodes_layout:
 
   'linux-06.he-eu-hel1.nimbus.prater':
     - { branch: 'stable',   start: 20404, end: 31303, build_freq: '*-*-* 11:00:00' } # 10899 validators
-    - { branch: 'testing',  start: 31303, end: 39202, build_freq: '*-*-* 15:00:00', open_libp2p_ports: false, nim_commit: 'version-1-6' } # 7899 validators
+    - { branch: 'testing',  start: 31303, end: 39202, build_freq: '*-*-* 15:00:00', validator_client: true, payload_builder: true, open_libp2p_ports: false, nim_commit: 'version-1-6' } # 7899 validators
     - { branch: 'unstable', start: 39202, end: 45101, build_freq: '*-*-* 13:00:00' } # 5899 validators
     - { branch: 'libp2p',   start: 45101, end: 49617, build_freq: '*-*-* 17:00:00', validator_client: true } # 4516 validators

--- a/ansible/group_vars/nimbus.ropsten.yml
+++ b/ansible/group_vars/nimbus.ropsten.yml
@@ -71,6 +71,8 @@ validator_client_build_frequency: 'daily'
 # Ports
 validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
+# MEV Payload Builder
+validator_client_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 # Keymanager
 validator_client_keymanager_enabled: true
 validator_client_keymanager_token: '{{lookup("bitwarden", "nimbus/keymanager", field="token")}}'

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -64,6 +64,8 @@ validator_client_build_frequency: 'daily'
 # Ports
 validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
+# MEV Payload Builder
+validator_client_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 # Keymanager
 validator_client_keymanager_enabled: true
 validator_client_keymanager_token: '{{lookup("bitwarden", "nimbus/keymanager", field="token")}}'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -61,7 +61,7 @@
 
 - name: infra-role-validator-client
   src: git@github.com:status-im/infra-role-validator-client.git
-  version: 4acb22624d2f00d30c3a028453cf36ab82aa578f
+  version: d5c2f2c54036a80e5775221c3965a94228d9d11c
   scm: git
 
 - name: infra-role-nimbus-eth1


### PR DESCRIPTION
To test our upcoming 22.11 release, we want to enable the validator client on the largest `testing` branch instance, with enabled support for an external block builder.

Before merging this, please merge
https://github.com/status-im/infra-role-validator-client/pull/1

... and bump the dependency here.