### PR TITLE
nimbus: set `--rest-allow-origin='*'` for `public_api`

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -55,6 +55,7 @@ beacon_node_build_frequency: '*-*-* {{ 12 + idx }}:00:00'
 # Tuning
 beacon_node_cores_per_node: '{{ (ansible_processor_vcpus / nodes_layout[hostname]|length) | round(0, "ceil") | int }}'
 beacon_node_threads: '{{ (node.branch == "libp2p") | ternary(1, beacon_node_cores_per_node) }}'
+beacon_node_rest_allow_origin: '{{ "*" if node.get("public_api") else "" }}'
 beacon_node_history_retention: '{{ "archive" if node.get("public_api") else node.get("history", "prune") }}'
 # Monitoring
 beacon_node_validator_monitor_auto: true

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -45,17 +45,17 @@
 
 - name: infra-role-beacon-node-linux
   src: git@github.com:status-im/infra-role-beacon-node-linux.git
-  version: edba943d039131f55818db69628fff1984fa5006
+  version: 03511966a3e37a9f938252664e8dd994bc6782e7
   scm: git
 
 - name: infra-role-beacon-node-windows
   src: git@github.com:status-im/infra-role-beacon-node-windows.git
-  version: e3d9f50136a9ca56f7e2cf2ea4d5af9a430fade5
+  version: de22753601da174ab1edf87b53fd996941bae4c7
   scm: git
 
 - name: infra-role-beacon-node-macos
   src: git@github.com:status-im/infra-role-beacon-node-macos.git
-  version: b00f8ba09d7beafe5450a80af21293953393729b
+  version: 04d162bd4b4803324034b7eef6f11e2bf6866838
   scm: git
 
 - name: infra-role-validator-client


### PR DESCRIPTION
To allow browser based clients to access our API servers.

Depends on:

- https://github.com/status-im/infra-role-beacon-node-linux/pull/14
- https://github.com/status-im/infra-role-beacon-node-linux/pull/15
- https://github.com/status-im/infra-role-beacon-node-macos/pull/7
- https://github.com/status-im/infra-role-beacon-node-macos/pull/8
- https://github.com/status-im/infra-role-beacon-node-windows/pull/6
- https://github.com/status-im/infra-role-beacon-node-windows/pull/7