### PR TITLE
nimbus.prater: switching MEV boots url.

### DIFF
--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -88,7 +88,7 @@ beacon_node_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 beacon_node_payload_builder_url: '{{ prater_mev_boost_urls[idx] }}'
 prater_mev_boost_urls:
   - 'https://bloxroute.max-profit.builder.goerli.blxrbdn.com'
-  - 'https://builder-relay-goerli.blocknative.com'
+  - 'https://goerli-relay.wenmerge.com'
   - 'https://goerli-relay.securerpc.com'
   - 'https://goerli.aestus.live'
   - 'https://relay-stag.ultrasound.money'


### PR DESCRIPTION
  Removing invalid url based on @tersec request.
  
  ```
$  curl https://builder-relay-goerli.blocknative.com/eth/v1/builder/status
{"error": "Service Unavailable"}
  ```
  List of valid URL available at https://ethstaker.cc/mev-relay-list#mev-relay-list-for-goerli-testnet