### PR TITLE
nimbus.mainnet: increase stable-small root volume size

### DIFF
--- a/mainnet.tf
+++ b/mainnet.tf
@@ -62,7 +62,7 @@ module "nimbus_nodes_mainnet_stable_small" {
 
   /* Scaling */
   type          = "t3a.large"
-  root_vol_size = 20
+  root_vol_size = 30
   data_vol_size = 600
   data_vol_type = "gp2"
   host_count    = 2


### PR DESCRIPTION
Nimbus logs take up to 10G on hosts.
And current disk space is 15-25%

Price increase - 1.19$ per month
https://aws.amazon.com/ebs/pricing/