### PR TITLE
holesky: use node branch in validator client name

### DIFF
--- a/ansible/group_vars/nimbus.holesky.yml
+++ b/ansible/group_vars/nimbus.holesky.yml
@@ -113,7 +113,7 @@ beacon_node_rest_address:   '0.0.0.0'
 
 # Validator Client -------------------------------------------------------------
 
-validator_client_service_name: 'validator-client-{{ validator_client_network }}-{{ validator_client_build_repo_branch }}'
+validator_client_service_name: 'validator-client-{{ validator_client_network }}-{{ node.branch }}'
 validator_client_service_enabled: '{{ node.get("vc", false) }}'
 validator_client_network: '{{ beacon_node_network }}'
 validator_client_log_level: 'INFO'


### PR DESCRIPTION
By using the `validator_client_build_repo_branch` instead of the `node.branch`, it will create a new directory when the branch name is override.