### PR TITLE
Remove BN stable-02 from holesky.mainnet

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -130,7 +130,6 @@ nodes_layout:
   # Innova Hosting ---------------------------------------------------
   'linux-01.ih-eu-mda1.nimbus.mainnet': # Frankenstein host, all nodes use one Geth.
     - { branch: 'stable',   num: 1 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1, open_libp2p_ports: false }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1, public_api: true }
@@ -138,7 +137,6 @@ nodes_layout:
 
   'linux-02.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   num: 1 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1, public_api: true }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1, open_libp2p_ports: false }
@@ -146,7 +144,6 @@ nodes_layout:
 
   'linux-03.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   num: 1, max_peers: 10000 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1 }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1 }
@@ -154,7 +151,6 @@ nodes_layout:
 
   'linux-04.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   num: 1 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1 }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1 }
@@ -162,7 +158,6 @@ nodes_layout:
 
   'linux-05.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   num: 1 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1 }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1 }
@@ -170,7 +165,6 @@ nodes_layout:
 
   'linux-06.ih-eu-mda1.nimbus.mainnet': # Doesn't exist yet.
     - { branch: 'stable',   num: 1 }
-    - { branch: 'stable',   num: 2 }
     - { branch: 'testing',  num: 1 }
     - { branch: 'testing',  num: 2 }
     - { branch: 'unstable', num: 1 }

--- a/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.mainnet.yml
@@ -5,4 +5,4 @@ beacon_node_rest_address: '0.0.0.0'
 # WARNING: This will change if number of nodes changes.
 redirect_ports:
   # beacon-node-mainnet-unstable-01
-  - { src: 80, dst: 9304, comment: 'Test Beacon API (80->9304/tcp)' }
+  - { src: 80, dst: 9303, comment: 'Test Beacon API (80->9304/tcp)' }

--- a/ansible/host_vars/linux-02.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/linux-02.ih-eu-mda1.nimbus.mainnet.yml
@@ -5,4 +5,4 @@ beacon_node_rest_address: '0.0.0.0'
 # WARNING: This will change if number of nodes changes.
 redirect_ports:
   # beacon-node-mainnet-testing-01
-  - { src: 80, dst: 9302, comment: 'Test Beacon API (80->9302/tcp)' }
+  - { src: 80, dst: 9301, comment: 'Test Beacon API (80->9302/tcp)' }


### PR DESCRIPTION
Beacon Node stable-02 removed from host to reduce load on hosts

Manually removed from host:
* service stopped
* All files related removed
* Related consul services unregistered: 
  * `build-beacon-node-mainnet-stable-02-timer`, 
  * `resync-beacon-node-mainnet-stable-02-timer`
  * `beacon-node-mainnet-stable-02-metrics`
  * `beacon-node-mainnet-stable-02`