### PR TITLE
Revert "nimbus.prater: use stable instead of unstable branch"

### DIFF
--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -48,10 +48,7 @@ beacon_node_era_dir_path: '{{ nimbus_era_files_timer_path }}'
 beacon_node_repo_branch: '{{ node_name_to_branch_map.get(node.branch, node.branch) }}'
 # We map short names to branches to avoid too long service names.
 node_name_to_branch_map:
-  # Avoid RPC but in current 'unstable' branch.
-  # https://github.com/status-im/nimbus-eth2/issues/5753
-  unstable: 'stable'
-  libp2p:   'nim-libp2p-auto-bump-unstable'
+  libp2p:  'nim-libp2p-auto-bump-unstable'
 # Ports
 beacon_node_discovery_port: '{{ 9000 + idx }}'
 beacon_node_listening_port: '{{ 9000 + idx }}'


### PR DESCRIPTION
This reverts commit c48ac78797484c48e02ba613d8e8cc90b6c5527e.

The underlying issue that prompted switching to `stable` has been fixed.

- https://github.com/status-im/nimbus-eth2/issues/5753