### PR TITLE
nimbus.prater: use custom research branch

### DIFF
--- a/ansible/group_vars/nimbus.prater.yml
+++ b/ansible/group_vars/nimbus.prater.yml
@@ -47,8 +47,12 @@ beacon_node_network: 'prater'
 beacon_node_era_dir_path: '{{ nimbus_era_files_timer_path }}'
 beacon_node_repo_branch: '{{ node_name_to_branch_map.get(node.branch, node.branch) }}'
 # We map short names to branches to avoid too long service names.
+# Prater is end of life and is used for research purposes on a custom branch
 node_name_to_branch_map:
-  libp2p:  'nim-libp2p-auto-bump-unstable'
+  libp2p:   'feat/splitview'
+  unstable: 'feat/splitview'
+  testing:  'feat/splitview'
+  stable:   'feat/splitview'
 # Ports
 beacon_node_discovery_port: '{{ 9000 + idx }}'
 beacon_node_listening_port: '{{ 9000 + idx }}'


### PR DESCRIPTION
As prater is approaching end of life, it is suitable for testing edge cases with partitioned network. To avoid interfering with other networks a separate branch should be tracked instead.