### PR TITLE
nimbus.fluffy: set amount of nodes back to 32

### DIFF
--- a/ansible/fluffy.yml
+++ b/ansible/fluffy.yml
@@ -19,6 +19,6 @@
   tasks:
     - include_role: name=infra-role-nimbus-fluffy
       tags: [ beacon-node, infra-role-nimbus-fluffy ]
-      with_sequence: start=1 end=16
+      with_sequence: start=1 end=32
       loop_control:
         loop_var: index


### PR DESCRIPTION
Not to merge before https://github.com/status-im/infra-role-nimbus-fluffy/pull/4 is applied.