### PR TITLE
nimbus.sepolia: host era1 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ These nodes have no validators attached.
 
 There are also archives of ERA files:
 
-| Endpoint                         | Host                                 |
-|----------------------------------|--------------------------------------|
-| https://mainnet.era.nimbus.team/ | `linux-03.ih-eu-mda1.nimbus.mainnet` |
-| https://sepolia.era.nimbus.team/ | `linux-01.ih-eu-mda1.nimbus.sepolia` |
-| https://holesky.era.nimbus.team/ | `geth-01.ih-eu-mda1.nimbus.holesky`  |
+| Endpoint                          | Host                                 |
+|-----------------------------------|--------------------------------------|
+| https://mainnet.era.nimbus.team/  | `linux-03.ih-eu-mda1.nimbus.mainnet` |
+| https://sepolia.era.nimbus.team/  | `linux-01.ih-eu-mda1.nimbus.sepolia` |
+| https://sepolia.era1.nimbus.team/ | `linux-01.ih-eu-mda1.nimbus.sepolia` |
+| https://holesky.era.nimbus.team/  | `geth-01.ih-eu-mda1.nimbus.holesky`  |
 
 # Dashboards
 

--- a/ansible/era.yml
+++ b/ansible/era.yml
@@ -15,10 +15,6 @@
     - linux-03.ih-eu-mda1.nimbus.mainnet
     - linux-01.ih-eu-mda1.nimbus.sepolia
     - geth-01.ih-eu-mda1.nimbus.holesky
-  vars:
-    open_ports_default_comment: 'Nginx'
-    open_ports_default_chain: 'SERVICES'
-    open_ports_list: [ { port: 80 }, { port: 443 } ]
   roles:
     - { role: infra-role-open-ports,   tags: open-ports   }
     - { role: infra-role-origin-certs, tags: origin-certs }

--- a/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
+++ b/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
@@ -1,5 +1,5 @@
 ---
-# Communityu test REST API endpoint.
+# Community test REST API endpoint.
 beacon_node_rest_address: '0.0.0.0'
 
 # Extract dynamically port form layout.

--- a/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.sepolia.yml
+++ b/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.sepolia.yml
@@ -21,6 +21,10 @@ redirect_ports:
 era_files_domain: 'sepolia.era.nimbus.team'
 era_files_path: '/data/era'
 
+# Era1 files hosting
+era1_files_domain: 'sepolia.era1.nimbus.team'
+era1_files_path: '/data/era1'
+
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'nimbus.team'
@@ -29,7 +33,7 @@ origin_certs:
 
 nginx_sites:
   era_files:
-    - listen 80 default_server
+    - listen 80
     - listen 443 ssl
 
     - server_name {{ era_files_domain }}
@@ -39,6 +43,21 @@ nginx_sites:
 
     - location / {
         root {{ era_files_path }};
+        autoindex on;
+        autoindex_format html;
+      }
+
+  era1_files:
+    - listen 80
+    - listen 443 ssl
+
+    - server_name {{ era1_files_domain }}
+
+    - ssl_certificate     /certs/nimbus.team/origin.crt
+    - ssl_certificate_key /certs/nimbus.team/origin.key
+
+    - location / {
+        root {{ era1_files_path }};
         autoindex on;
         autoindex_format html;
       }

--- a/sepolia.tf
+++ b/sepolia.tf
@@ -21,3 +21,12 @@ resource "cloudflare_record" "unstable_sepolia_beacon_api" {
   type    = "A"
   proxied = false
 }
+
+/* ERA1 Files hosting */
+resource "cloudflare_record" "era1_sepolia" {
+  zone_id = local.zones["nimbus.team"]
+  name    = "sepolia.era1"
+  value   = module.nimbus_nodes_sepolia_innova.public_ips[0]
+  type    = "A"
+  proxied = true
+}


### PR DESCRIPTION
The PR sets up hosting for era1 files for sepolia.
Available here -> https://sepolia.era1.nimbus.team/


status: changes applied