### PR TITLE
kibana: Moved from Github to Keycloak auth

### DIFF
--- a/ansible/group_vars/dash.nimbus.yml
+++ b/ansible/group_vars/dash.nimbus.yml
@@ -29,7 +29,7 @@ oauth_domain: '{{ kibana_domain }}'
 oauth_upstream_addr: '{{ kibana_cont_name }}'
 oauth_upstream_port: '{{ kibana_cont_port }}'
 oauth_local_port: 4180
-oauth_provider: 'github'
+oauth_provider: 'keycloak-oidc'
 oauth_id: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="client-id") }}'
 oauth_secret: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="secret") }}'
 oauth_cookie_secret: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="cookie-secret") }}'


### PR DESCRIPTION
Allowed access to Kibana dashboard to anyone with an account in Keycloak realm `logos-co`. Updated values in Bitwarden for client id and secret.

Referenced issue: https://github.com/status-im/infra-misc/issues/285