### PR TITLE
mainnet: switch from iptables to nftables

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -108,16 +108,27 @@ nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-stable-01/data/db'
 nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-stable-01/repo/build/ncli_db'
 
+# Migrated to NFTables from IPTables.
+# https://github.com/status-im/infra-misc/issues/301
+bootstrap__firewall_nftables: true
+
 # Open Ports
-open_ports_default_comment: 'Nimbus REST API'
-open_ports_default_chain: 'VPN'
 open_ports_list:
-  - { port: '80',                              chain: 'SERVICES',       comment: 'Nginx' }
-  - { port: '443',                             chain: 'SERVICES',       comment: 'Nginx' }
-  - { port: '9300:9310',                       ipset: '{{ env }}.{{ stage }}' }
-  - { port: '9400',                            ipset: 'metrics.hq',     comment: 'Geth Exporter' }
-  - { port: '{{ smart_metrics_listen_port }}', ipset: 'metrics.hq',     comment: 'SMART Metrics' }
-  - { port: '{{ geth_authrpc_port }}',         ipset: 'nimbus.mainnet', comment: 'Geth RPC'      }
-  - { port: '{{ geth_rpc_port }}',             ipset: 'nimbus.fluffy',  comment: 'Portal Bridge' }
+  nginx:
+      - { port: '443',  comment: 'Nginx' }
+  smart-metrics:
+      - { port: '{{ smart_metrics_listen_port }}', comment: 'SMART Metrics', ipset: 'metrics.hq', iifname: 'wg0' }
+  geth-node:
+      - { port: '{{ geth_port }}',           comment: 'Go-Ethereum libp2p',    protocol: 'tcp'                                }
+      - { port: '{{ geth_port }}',           comment: 'Go-Ethereum discovery', protocol: 'udp'                                } 
+      - { port: '{{ geth_expo_cont_port }}', comment: 'Go-Ethereum Exporter',  ipset: 'metrics.hq',            iifname: 'wg0' } 
+      - { port: '{{ geth_authrpc_port }}',   comment: 'Go-Ethereum AuthRPC',   ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' } 
+      - { port: '{{ geth_rpc_port }}',       comment: 'RPC for Portal Bridge', ipset: 'nimbus.fluffy',         iifname: 'wg0' } 
+  beacon-node:
+      - { port: '9000-9005', comment: 'Beacon Node libp2p',    protocol: 'tcp'                                    }
+      - { port: '9000-9005', comment: 'Beacon Node discovery', protocol: 'udp'                                    }
+      - { port: '9200-9205', comment: 'Beacon Node Metrics',   ipset: 'metrics.hq',                iifname: 'wg0' }
+      - { port: '9300-9305', comment: 'Beacon Node REST API',  ipset: '{{ env }}.{{ stage }}',     iifname: 'wg0' }
+  
 
 # Fleet layout can be found in: ansible/vars/layout/mainnet.yml

--- a/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
@@ -11,3 +11,17 @@ beacon_node_subscribe_all: false
 # These bootstrap nodes were published with these ports.
 beacon_node_discovery_port: 9100
 beacon_node_listening_port: 9100
+beacon_node_metrics_port: 9200
+beacon_node_rest_port: 9300
+
+# Open Ports
+open_ports_list:
+  nginx:
+      - { port: '443',  comment: 'Nginx' }
+  smart-metrics:
+      - { port: '{{ smart_metrics_listen_port }}', comment: 'SMART Metrics', ipset: 'metrics.hq', iifname: 'wg0' }
+  beacon-node:
+      - { port: '{{ beacon_node_discovery_port }}', comment: 'Beacon Node libp2p',    protocol: 'tcp'                                }
+      - { port: '{{ beacon_node_discovery_port }}', comment: 'Beacon Node discovery', protocol: 'udp'                                }
+      - { port: '{{ beacon_node_metrics_port }}',   comment: 'Beacon Node Metrics',   ipset: 'metrics.hq',            iifname: 'wg0' }
+      - { port: '{{ beacon_node_rest_port }}',      comment: 'Beacon Node REST API',  ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' }

--- a/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
@@ -11,3 +11,17 @@ beacon_node_subscribe_all: false
 # These bootstrap nodes were published with these ports.
 beacon_node_discovery_port: 9100
 beacon_node_listening_port: 9100
+beacon_node_metrics_port: 9200
+beacon_node_rest_port: 9300
+
+# Open Ports
+open_ports_list:
+  nginx:
+      - { port: '443',  comment: 'Nginx' }
+  smart-metrics:
+      - { port: '{{ smart_metrics_listen_port }}', comment: 'SMART Metrics', ipset: 'metrics.hq', iifname: 'wg0' }
+  beacon-node:
+      - { port: '{{ beacon_node_discovery_port }}', comment: 'Beacon Node libp2p',    protocol: 'tcp'                                }
+      - { port: '{{ beacon_node_discovery_port }}', comment: 'Beacon Node discovery', protocol: 'udp'                                }
+      - { port: '{{ beacon_node_metrics_port }}',   comment: 'Beacon Node Metrics',   ipset: 'metrics.hq',            iifname: 'wg0' }
+      - { port: '{{ beacon_node_rest_port }}',      comment: 'Beacon Node REST API',  ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' }

--- a/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.mainnet.yml
@@ -12,6 +12,7 @@ test_api_beacon_node_branch: |-
   {{ nodes_layout[inventory_hostname][test_api_beacon_node_rest_index|int].branch }}
 
 redirect_ports:
-  - src: 80
+  public-beacon-api:
+    src: 80
     dst: '{{ test_api_beacon_node_rest_port }}'
-    comment: 'Public Beacon API ({{ test_api_beacon_node_branch }})'
+    comment: 'Public Beacon API ({{ test_api_beacon_node_branch }}-0{{ test_api_beacon_node_rest_index|int - 1 }})'

--- a/ansible/host_vars/linux-02.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/linux-02.ih-eu-mda1.nimbus.mainnet.yml
@@ -13,6 +13,7 @@ test_api_beacon_node_branch: |-
 
 # WARNING: This will change if number of nodes changes.
 redirect_ports:
-  - src: 80
+  public-beacon-api:
+    src: 80
     dst: '{{ test_api_beacon_node_rest_port }}'
-    comment: 'Public Beacon API ({{ test_api_beacon_node_branch }})'
+    comment: 'Public Beacon API ({{ test_api_beacon_node_branch }}-0{{ test_api_beacon_node_rest_index|int - 1 }})'

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -19,6 +19,7 @@
     beacon_node_netkey: '{{lookup("bitwarden", "nimbus/netkey", field=hostname)}}'
   roles:
     - { role: infra-role-swap-file,         tags: [ swap-file ] }
+    - { role: infra-role-open-ports,        tags: [ open-ports ] }    
     - { role: redirect-ports,               tags: [ redirect-ports ] }
     - { role: get-geth-api-urls,            tags: [ get-geth-api-urls, beacon-node ] }
   tasks:


### PR DESCRIPTION
Switch these hosts from iptables to nftables: 

[nimbus.mainnet]
- [x] bootstrap-01.aws-eu-central-1a.nimbus.mainnet
- [x] bootstrap-02.aws-eu-central-1a.nimbus.mainnet
- [x] linux-01.ih-eu-mda1.nimbus.mainnet
- [x] linux-02.ih-eu-mda1.nimbus.mainnet
- [x] linux-03.ih-eu-mda1.nimbus.mainnet
- [x] linux-04.ih-eu-mda1.nimbus.mainnet
- [x] linux-05.ih-eu-mda1.nimbus.mainnet
- [x] linux-06.ih-eu-mda1.nimbus.mainnet
- [x] linux-07.ih-eu-mda1.nimbus.mainnet

- `bootstrap-01` and `bootstrap-02` required narrowed `open_ports_list` which was added in `host_vars` files

Reference: https://github.com/status-im/infra-misc/issues/301