### PR TITLE
Migrate to infra-nimbus from bitwarden to vault

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,18 +2,18 @@
 mev_boost_enabled: false
 
 # Root password
-bootstrap__root_pass: '{{lookup("bitwarden", "root-pass")}}'
-bootstrap__admin_pass: '{{lookup("bitwarden", "macos/admin", field="password")}}'
+bootstrap__root_pass:               '{{lookup("vault", "hosts",             field="root-pass",        stage="all", env="all")}}'
+bootstrap__admin_pass:              '{{lookup("vault", "hosts",             field="macos-admin-pass", stage="all", env="all")}}'
 # Consul
-bootstrap__consul_encryption_key:   '{{lookup("bitwarden", "consul/cluster",    field="encryption-key")}}'
-bootstarp__consul_agent_acl_token:  '{{lookup("bitwarden", "consul/acl-tokens", field="agent-default")}}'
-bootstrap__consul_certs_ca_crt:     '{{lookup("bitwarden", "consul/certs",      file="ca.pem")}}'
-bootstrap__consul_certs_client_crt: '{{lookup("bitwarden", "consul/certs",      file="client.pem")}}'
-bootstrap__consul_certs_client_key: '{{lookup("bitwarden", "consul/certs",      file="client-key.pem")}}'
+bootstrap__consul_encryption_key:   '{{lookup("vault", "consul/config",      field="encryption-key",   stage="all", env="all")}}'
+bootstarp__consul_agent_acl_token:  '{{lookup("vault", "consul/acl-tokens", field="agent-default",    stage="all", env="all")}}'
+bootstrap__consul_certs_ca_crt:     '{{lookup("vault", "consul/certs",      field="ca.pem",           stage="all", env="all")}}'
+bootstrap__consul_certs_client_crt: '{{lookup("vault", "consul/certs",      field="client.pem",       stage="all", env="all")}}'
+bootstrap__consul_certs_client_key: '{{lookup("vault", "consul/certs",      field="client-key.pem",   stage="all", env="all")}}'
 # SSHGuard
-bootstrap__sshguard_whitelist_extra: ['{{lookup("bitwarden", "sshguard/whitelist", field="jakubgs-home")}}']
+bootstrap__sshguard_whitelist_extra: ['{{lookup("vault", "sshguard/whitelist", field="jakubgs-home",  stage="all", env="all")}}']
 # Wireguard
-wireguard_consul_acl_token: '{{lookup("bitwarden", "consul/acl-tokens", field="wireguard")}}'
+wireguard_consul_acl_token:           '{{lookup("vault", "consul/acl-tokens",  field="wireguard",     stage="all", env="all")}}'
 
 # Custom SSH accounts for Nimbus fleet, should start from UID 8000.
 bootstrap__active_extra_users:

--- a/ansible/group_vars/dash.nimbus.yml
+++ b/ansible/group_vars/dash.nimbus.yml
@@ -6,8 +6,8 @@ swap_file_size_mb: 2048
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'status.im'
-    crt: '{{lookup("bitwarden", "Cloudflare/status.im", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "Cloudflare/status.im", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
     default: true
 
 # Kibana Dashboard
@@ -30,9 +30,9 @@ oauth_upstream_addr: '{{ kibana_cont_name }}'
 oauth_upstream_port: '{{ kibana_cont_port }}'
 oauth_local_port: 4180
 oauth_provider: 'keycloak-oidc'
-oauth_id: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="client-id") }}'
-oauth_secret: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="secret") }}'
-oauth_cookie_secret: '{{ lookup("bitwarden", "nimbus/kibana/oauth", field="cookie-secret") }}'
+oauth_id:            '{{lookup("vault", "kibana/oauth", field="client-id")}}'
+oauth_secret:        '{{lookup("vault", "kibana/oauth", field="secret")}}'
+oauth_cookie_secret: '{{lookup("vault", "kibana/oauth", field="cookie-secret")}}'
 
 # ElasticSearch Load Balancer
 es_lb_service_name: 'elasticsearch'

--- a/ansible/group_vars/logs.nimbus.yml
+++ b/ansible/group_vars/logs.nimbus.yml
@@ -2,8 +2,8 @@
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'status.im'
-    crt: '{{lookup("bitwarden", "Cloudflare/status.im", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "Cloudflare/status.im", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
     default: true
 
 # Syncing can use a lot of memory

--- a/ansible/group_vars/nimbus-geth-holesky.yml
+++ b/ansible/group_vars/nimbus-geth-holesky.yml
@@ -12,8 +12,8 @@ geth_sync_mode: 'full'
 geth_log_level_name: info
 geth_consul_advertised_address: '{{ inventory_hostname }}.wg'
 # Geth auth & JWT token
-geth_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
-geth_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+geth_account_pass:      '{{lookup("vault", "geth",       field="password",  stage="all")}}'
+geth_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Memory settings
 geth_cont_mem_ratio: 0.8
 geth_cache_size: '{{ (ansible_memtotal_mb * 0.25|float) | int }}'

--- a/ansible/group_vars/nimbus-geth-mainnet.yml
+++ b/ansible/group_vars/nimbus-geth-mainnet.yml
@@ -11,8 +11,8 @@ geth_sync_mode: 'snap'
 geth_log_level_name: info
 geth_websocket_enabled: true
 # Geth auth & JWT token
-geth_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
-geth_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+geth_account_pass:      '{{lookup("vault", "geth",       field="password",  stage="all")}}'
+geth_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Memory settings
 geth_cont_mem_ratio: 0.7
 

--- a/ansible/group_vars/nimbus.eth1.yml
+++ b/ansible/group_vars/nimbus.eth1.yml
@@ -23,7 +23,7 @@ rocketpool_eth1_archive_url: 'http://localhost:{{ nimbus_eth1_http_port }}'
 rocketpool_password: '{{lookup("passwordstore", "services/Rocketpool/test/Eth1/pass")}}'
 rocketpool_wallet: '{{lookup("passwordstore", "services/Rocketpool/test/Eth1/wallet")}}'
 # Transaction Fees
-rocketpool_eth2_fee_recipient: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="address")}}'
+rocketpool_eth2_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 
 # Nimbus Eth1 node
 nimbus_eth1_repo_branch: 'master'
@@ -36,7 +36,7 @@ nimbus_eth1_discovery_port: 30303
 nimbus_eth1_metrics_port: 9093
 nimbus_eth1_metrics_address: '0.0.0.0'
 # API secert
-nimbus_eth1_jwt_secret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+nimbus_eth1_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 
 # Migrated to NFTables from IPTables.
 # https://github.com/status-im/infra-misc/issues/301

--- a/ansible/group_vars/nimbus.holesky.yml
+++ b/ansible/group_vars/nimbus.holesky.yml
@@ -15,8 +15,8 @@ geth_cont_vol: '{{ geth_service_path }}/node'
 geth_sync_mode: 'full'
 geth_log_level_name: 'info'
 # Geth auth & JWT token
-geth_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
-geth_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+geth_account_pass:      '{{lookup("vault", "geth",       field="password",  stage="all")}}'
+geth_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Memory settings
 geth_cont_mem_ratio: 0.2
 # Ports
@@ -43,7 +43,7 @@ erigon_log_level: 'info'
 erigon_cont_mem_ratio: 0.15
 erigon_max_peers: 20
 erigon_miner_enabled: true
-erigon_mining_private_key: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="private-key")}}'
+erigon_mining_private_key: '{{lookup("vault", "testnet-wallet", field="private-key", stage="all")}}'
 # Ports
 erigon_metrics_enabled: true
 erigon_rpc_addr: '0.0.0.0'
@@ -53,15 +53,15 @@ erigon_p2p_allowed_ports: ['{{ erigon_port }}', '{{ erigon_port|int + 1 }}']
 erigon_rpc_port:          '{{ exec_layer_rpc_port }}'
 erigon_metrics_port:      '{{ exec_layer_metrics_port }}'
 erigon_authrpc_port:      '{{ exec_layer_authrpc_port }}'
-erigon_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+erigon_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 
 # Nethermind -------------------------------------------------------------------
 
 nethermind_network_name: 'holesky'
 nethermind_service_name: 'nethermind-{{ nethermind_network_name }}-{{ "%02d"|format(idx|int+1) }}'
 nethermind_service_path: '/docker/{{ nethermind_service_name }}'
-nethermind_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
-nethermind_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+nethermind_account_pass:      '{{lookup("vault", "geth",       field="password",  stage="all")}}'
+nethermind_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 nethermind_sync_mode: 'snap'
 nethermind_port:         '{{ exec_layer_p2p_port }}'
 nethermind_rpc_port:     '{{ exec_layer_rpc_port }}'
@@ -93,9 +93,9 @@ beacon_node_validator_monitor_details: >-
 beacon_node_exec_layer_urls: ['http://localhost:{{ exec_layer_authrpc_port }}']
 beacon_node_exec_layer_jwt_secret: '{{ geth_authrpc_jwtsecret | mandatory }}'
 # Suggests it to the Execution Layer client.
-beacon_node_suggested_fee_recipient: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="address")}}'
+beacon_node_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # Windows service user
-beacon_node_service_user_pass: '{{lookup("bitwarden", "nimbus/windows", field="password")}}'
+beacon_node_service_user_pass: '{{lookup("vault", "windows-service-user", field="password", stage="all")}}'
 # MEV Payload Builder
 beacon_node_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 beacon_node_payload_builder_url: 'https://boost-relay-holesky.flashbots.net/'
@@ -137,10 +137,10 @@ validator_client_build_frequency: 'daily'
 validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
 # Suggests it to the Execution Layer client and the builder network.
-validator_client_suggested_fee_recipient: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="address")}}'
+validator_client_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # Keymanager
 validator_client_keymanager_enabled: true
-validator_client_keymanager_token: '{{lookup("bitwarden", "nimbus/keymanager", field="token")}}'
+validator_client_keymanager_token: '{{lookup("vault", "validator-client", field="keymanager-token", stage="all")}}'
 # Validators Distribution
 validator_client_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 validator_client_dist_validators_start: '{{ (not node.get("vc", false)) | ternary(0, node.start) | mandatory }}'

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -22,7 +22,7 @@ geth_cont_vol: '{{ geth_service_path }}/node'
 geth_sync_mode: 'snap'
 geth_log_level_name: 'info'
 # Geth auth & JWT token
-geth_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
+geth_account_pass: '{{lookup("vault", "geth", field="password", stage="all")}}'
 geth_authrpc_jwtsecret: '{{ beacon_node_exec_layer_jwt_secret }}'
 # Memory settings
 geth_cont_mem_ratio: 0.15
@@ -105,7 +105,7 @@ beacon_node_update_frequency: '*-*-* {{ "%02d" | format(idx * 2) }}:00:00'
 beacon_node_validator_monitor_auto: true
 beacon_node_validator_monitor_details: '{{ node.public_api is not defined or not node.public_api }}'
 # Execution layer Enginer API
-beacon_node_exec_layer_jwt_secret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+beacon_node_exec_layer_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 beacon_node_exec_layer_urls_local: ['http://localhost:{{ exec_layer_authrpc_port }}']
 beacon_node_exec_layer_urls: '{{ beacon_node_exec_layer_urls_local if node.get("el") else [] }}'
 # Light client data

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -8,8 +8,8 @@ geth_cont_vol: '{{ geth_service_path }}/node'
 geth_sync_mode: 'full'
 geth_log_level_name: info
 # Geth auth & JWT token
-geth_account_pass: '{{lookup("bitwarden", "nimbus/geth", field="password")}}'
-geth_authrpc_jwtsecret: '{{lookup("bitwarden", "nimbus/jwt-token")}}'
+geth_account_pass:      '{{lookup("vault", "geth",       field="password",  stage="all")}}'
+geth_authrpc_jwtsecret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Memory settings
 geth_cont_mem_ratio: 0.3
 # Genesis
@@ -51,7 +51,7 @@ beacon_node_validator_monitor_details: true
 beacon_node_exec_layer_urls: ['http://localhost:{{ geth_authrpc_port }}']
 beacon_node_exec_layer_jwt_secret: '{{ geth_authrpc_jwtsecret | mandatory }}'
 # Suggests it to the Execution Layer client.
-beacon_node_suggested_fee_recipient: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="address")}}'
+beacon_node_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # Validators from nimbus-private repo¬
 beacon_node_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 beacon_node_dist_validators_start: '{{ node.vc | ternary(0, node.start) | mandatory }}'
@@ -91,12 +91,12 @@ geth_expo_source_data_path: '{{ geth_cont_vol }}/data'
 geth_expo_cont_port:  '{{ 9400 + (idx|int) + 1 }}'
 
 # Suggests it to the Execution Layer client and the builder network.
-validator_client_suggested_fee_recipient: '{{lookup("bitwarden", "nimbus/wallet/testnets", field="address")}}'
+validator_client_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # MEV Payload Builder
 validator_client_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 # Keymanager
 validator_client_keymanager_enabled: true
-validator_client_keymanager_token: '{{lookup("bitwarden", "nimbus/keymanager", field="token")}}'
+validator_client_keymanager_token: '{{lookup("vault", "validator-client", field="keymanager-token", stage="all")}}'
 # Validators Distribution
 validator_client_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 validator_client_dist_validators_start: '{{ (not node.vc) | ternary(0, node.start) | mandatory }}'

--- a/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
@@ -3,7 +3,7 @@ swap_file_path: '/main.swap'
 swap_file_size_mb: 4096
 
 # WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
-beacon_node_netkey: '{{lookup("bitwarden", "nimbus/netkey", field=hostname)}}'
+beacon_node_netkey: '{{lookup("vault", "beacon-node/netkey", field=hostname)}}'
 
 # Not necessary to stress test bootnodes.
 beacon_node_subscribe_all: false

--- a/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
@@ -3,7 +3,7 @@ swap_file_path: '/main.swap'
 swap_file_size_mb: 4096
 
 # WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
-beacon_node_netkey: '{{lookup("bitwarden", "nimbus/netkey", field=hostname)}}'
+beacon_node_netkey: '{{lookup("vault", "beacon-node/netkey", field=hostname)}}'
 
 # Not necessary to stress test bootnodes.
 beacon_node_subscribe_all: false

--- a/ansible/host_vars/erigon-01.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/erigon-01.ih-eu-mda1.nimbus.mainnet.yml
@@ -5,8 +5,8 @@ era_files_path: '/data/era'
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'nimbus.team'
-    crt: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
 
 nginx_sites:
   era_files:

--- a/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
+++ b/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
@@ -25,8 +25,8 @@ era_files_path: '/data/era'
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'nimbus.team'
-    crt: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
 
 nginx_sites:
   era_files:

--- a/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.sepolia.yml
+++ b/ansible/host_vars/linux-01.ih-eu-mda1.nimbus.sepolia.yml
@@ -29,8 +29,8 @@ era1_files_path: '/data/era1'
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'nimbus.team'
-    crt: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
 
 nginx_sites:
   era_files:

--- a/ansible/host_vars/nec-01.ih-eu-mda1.nimbus.mainnet.yml
+++ b/ansible/host_vars/nec-01.ih-eu-mda1.nimbus.mainnet.yml
@@ -6,8 +6,8 @@ era1_files_path: '/docker/era1'
 # CloudFlare Origin certificates
 origin_certs:
   - domain: 'nimbus.team'
-    crt: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.crt")}}'
-    key: '{{lookup("bitwarden", "CloudFlare/nimbus.team", file="origin.key")}}'
+    crt: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.crt", stage="all", env="all")}}'
+    key: '{{lookup("vault", "certs/cloudflare/nimbus.team", field="origin.key", stage="all", env="all")}}'
 
 nginx_sites:
   era1_files:

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -16,7 +16,7 @@
   vars_files: layout/mainnet.yml
   vars:
     # WARNING: Since these are Eth 2 bootnodes we need to keep the keys and IPs unchanged.
-    beacon_node_netkey: '{{lookup("bitwarden", "nimbus/netkey", field=hostname)}}'
+    beacon_node_netkey: '{{lookup("vault", "beacon-node/netkey", field=hostname)}}'
   roles:
     - { role: infra-role-swap-file,         tags: [ swap-file ] }
     - { role: infra-role-open-ports,        tags: [ open-ports ] }

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,7 +26,7 @@
 
 - name: infra-role-oauth-proxy
   src: git@github.com:status-im/infra-role-oauth-proxy.git
-  version: 7ce78de798ee8c1e4ecd8c0e6d23d86889d57839
+  version: fcddc3c2d10d0c53e3046f6c0ad81073c6f49753
 
 - name: infra-role-consul-service
   src: git@github.com:status-im/infra-role-consul-service.git
@@ -46,11 +46,11 @@
 
 - name: infra-role-validator-client
   src: git@github.com:status-im/infra-role-validator-client.git
-  version: 851e41dcf58ef14c33b2bd7f11b985327adbe391
+  version: 7750aed23197d8d931bd2a28af6a0673130fe97f
 
 - name: infra-role-nimbus-eth1
   src: git@github.com:status-im/infra-role-nimbus-eth1.git
-  version: 63727b1962c8e052d8dd7c23ae592eedcd1892b1
+  version: 4765dd6ac3b9e1afaaaefee5423a3d6c7c9269d2
 
 - name: infra-role-nimbus-fluffy
   src: git@github.com:status-im/infra-role-nimbus-fluffy.git
@@ -66,7 +66,7 @@
 
 - name: infra-role-rocketpool
   src: git@github.com:status-im/infra-role-rocketpool.git
-  version: f19a7e5b7ad8f8b11f9a96fa84c26c66dccd61f7
+  version: 5af21f2dec46cdfa9b1a5d7e26c56300088ae2d7
 
 - name: infra-role-winsw
   src: git@github.com:status-im/infra-role-winsw.git
@@ -94,11 +94,11 @@
 
 - name: infra-role-geth
   src: git@github.com:status-im/infra-role-geth.git
-  version: 834052fed5084041755cb3b8bf1449a984f98a27
+  version: e26684090210283948b21987f6a665ca345269fc
 
 - name: infra-role-geth-exporter
   src: git@github.com:status-im/infra-role-geth-exporter.git
-  version: 0859bd5b4a5010a7377c01ea3b4bb26195a594f4
+  version: 3ef3b7e7b60c6eadf9e902915fc2c1d150c3629a
 
 - name: infra-role-erigon
   src: git@github.com:status-im/infra-role-erigon.git


### PR DESCRIPTION
## Summary

This PR moves over the secrets used in infra-nimbus from `bitwarden` to `vault`
I have verified these changes by running related ansible playbooks with the `--check` flag.

related issue : https://github.com/status-im/infra-hq/issues/142