### PR TITLE
configure short and long benchmarking service

### DIFF
--- a/ansible/bench.yml
+++ b/ansible/bench.yml
@@ -1,0 +1,30 @@
+---
+- name: Verify Ansible versions
+  hosts: all
+  tags: always
+  become: false
+  run_once: true
+  gather_facts: false
+  tasks:
+    - local_action: command ./roles.py --check
+      changed_when: false
+
+- name: Configure Short Benchmarking Eth1 node
+  become: true
+  vars_files: group_vars/nimbus-bench.eth1.yml
+  tags: short-benchmark
+  hosts:
+    - bench-01.he-eu-hel1.nimbus.eth1
+  roles:
+    - { role: infra-role-open-ports,        tags: open-ports  }
+    - { role: infra-role-nimbus-bench-eth1, tags: nimbus-bench,  vars: { nimbus_eth1_benchmark_type: 'short'} }
+
+- name: Configure Long Benchmarking Eth1 node
+  become: true
+  vars_files: group_vars/nimbus-bench.eth1.yml
+  tags: long-benchmark
+  hosts:
+      - bench-02.he-eu-hel1.nimbus.eth1
+  roles:
+    - { role: infra-role-open-ports,        tags: open-ports  }
+    - { role: infra-role-nimbus-bench-eth1, tags: nimbus-bench,  vars: { nimbus_eth1_benchmark_type: 'long'} }

--- a/ansible/group_vars/nimbus-bench.eth1.yml
+++ b/ansible/group_vars/nimbus-bench.eth1.yml
@@ -1,0 +1,21 @@
+---
+# Nimbus Eth1 node
+nimbus_eth1_repo_branch: 'master'
+nimbus_eth1_network: 'mainnet'
+nimbus_eth1_max_peers: 160
+nimbus_eth1_log_level: 'DEBUG'
+# Ports
+## EL
+nimbus_eth1_listening_port:  30303
+nimbus_eth1_discovery_port:  30303
+nimbus_eth1_metrics_port:    9093
+nimbus_eth1_metrics_address: '0.0.0.0'
+nimbus_eth1_era_dir: '/data/era'
+nimbus_eth1_era1_dir: '/data/era1'
+
+# Open Ports -------------------------------------------------------------------
+open_ports_list:
+  el-node:
+    - { port: '{{ nimbus_eth1_listening_port }}', comment: 'Nimbus node listening port', protocol: 'tcp' }
+    - { port: '{{ nimbus_eth1_discovery_port }}', comment: 'Nimbus node discovery port', protocol: 'udp' }
+    - { port: '{{ nimbus_eth1_metrics_port }}',   comment: 'Nimbus node metrics port', ipset: 'hq.metrics', iifname: 'wg0' }

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -115,3 +115,7 @@
 - name: infra-role-mev-boost
   src: git@github.com:status-im/infra-role-mev-boost.git
   version: 2c9fa57c55d692404392ab0fd4fddb007881b228
+
+- name: infra-role-nimbus-bench-eth1
+  src: git@github.com:status-im/infra-role-nimbus-bench-eth1.git
+  version: 441ab7825c617dbba2257d0ff058a111f4c6814c


### PR DESCRIPTION
## Summary

This PR uses `infra-role-nimbus-bench-eth1` to deploy short and long benchmarking service on : 
- `bench-01.he-eu-hel1.nimbus.eth1`
- `bench-02.he-eu-hel1.nimbus.eth1`