### PR TITLE
nimbus: add nimbus light-client service

### DIFF
--- a/ansible/group_vars/nimbus.holesky.yml
+++ b/ansible/group_vars/nimbus.holesky.yml
@@ -125,6 +125,7 @@ beacon_node_payload_builder_url: 'https://boost-relay-holesky.flashbots.net/'
 beacon_node_light_client_data_enabled: '{{ (node.public_api is defined and node.public_api) }}'
 beacon_node_light_client_data_serve: true
 beacon_node_light_client_data_import_mode: 'full'
+light_client_network: 'holesky'
 # Validators from nimbus-private repo¬
 beacon_node_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 beacon_node_dist_validators_start: '{{ node.get("vc", false) | ternary(0, node.start) | mandatory }}'
@@ -200,5 +201,8 @@ open_ports_list:
   validator-client:
     - { port: '5053-5056', comment: 'Validator Client REST API', ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' }
     - { port: '8109-8112', comment: 'Validator Client Metrics',  ipset: 'hq.metrics',            iifname: 'wg0' }
+  nimbus-light-client:
+    - { port: '9503', comment: 'Nimbus Light Client LibP2P',    protocol: 'tcp' }
+    - { port: '9503', comment: 'Nimbus Light Client Discovery', protocol: 'udp' }
 
 # Fleet layout can be found in: ansible/vars/layout/holesky.yml

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -109,6 +109,7 @@ beacon_node_exec_layer_urls: '{{ beacon_node_exec_layer_urls_local if node.get("
 beacon_node_light_client_data_enabled: '{{ (node.public_api is defined and node.public_api) }}'
 beacon_node_light_client_data_serve: true
 beacon_node_light_client_data_import_mode: 'full'
+light_client_network: 'mainnet'
 # Mainnet validators run on a separate fleet.
 beacon_node_dist_validators_enabled: false
 # Ports
@@ -166,5 +167,7 @@ open_ports_list:
     - { port: '9001-9004', comment: 'Beacon Node discovery', protocol: 'udp'                                    }
     - { port: '9201-9204', comment: 'Beacon Node Metrics',   ipset: 'hq.metrics',                iifname: 'wg0' }
     - { port: '9301-9304', comment: 'Beacon Node REST API',  ipset: '{{ env }}.{{ stage }}',     iifname: 'wg0' }
-
+  nimbus-light-client:
+    - { port: '9503', comment: 'Nimbus Light Client LibP2P',    protocol: 'tcp' }
+    - { port: '9503', comment: 'Nimbus Light Client Discovery', protocol: 'udp' }
 # Fleet layout can be found in: ansible/vars/layout/mainnet.yml

--- a/ansible/holesky.yml
+++ b/ansible/holesky.yml
@@ -19,12 +19,13 @@
     - nimbus-holesky-neth
   vars_files: layout/holesky.yml
   roles:
-    - { role: update-netplan,        tags: update-netplan,    when: ansible_system == 'Linux' }
-    - { role: infra-role-swap-file,  tags: swap-file        }
-    - { role: infra-role-open-ports, tags: open-ports       }
-    - { role: redirect-ports,        tags: redirect-ports   }
-    - { role: nimbus-era-files,      tags: nimbus-era-files }
-    - { role: infra-role-mev-boost,  tags: mev-boost,    when: mev_boost_enabled == true }
+    - { role: update-netplan,                 tags: update-netplan,    when: ansible_system == 'Linux' }
+    - { role: infra-role-swap-file,           tags: swap-file        }
+    - { role: infra-role-open-ports,          tags: open-ports       }
+    - { role: redirect-ports,                 tags: redirect-ports   }
+    - { role: nimbus-era-files,               tags: nimbus-era-files }
+    - { role: infra-role-mev-boost,           tags: mev-boost,    when: mev_boost_enabled == true }
+    - { role: infra-role-nimbus-light-client, tags: nimbus-light-client }
   tasks:
     - include_role:
         name: infra-role-beacon-node-linux

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -44,13 +44,14 @@
     # FIXME: Use all Geth nodes available in the fleet until we resync.
     geth_node_api_fleet_names: ['nimbus.geth']
   roles:
-    - { role: update-netplan,               tags: [ update-netplan ], when: ansible_system == 'Linux' }
-    - { role: infra-role-swap-file,         tags: [ swap-file ] }
-    - { role: infra-role-open-ports,        tags: [ open-ports ] }
-    - { role: infra-role-smart-metrics,     tags: [ smart-metrics ] }
-    - { role: redirect-ports,               tags: [ redirect-ports ] }
-    - { role: get-geth-api-urls,            tags: [ get-geth-api-urls, beacon-node ] }
-    - { role: nimbus-era-files,             tags: [ nimbus-era-files ] }
+    - { role: update-netplan,                 tags: [ update-netplan ], when: ansible_system == 'Linux' }
+    - { role: infra-role-swap-file,           tags: [ swap-file ] }
+    - { role: infra-role-open-ports,          tags: [ open-ports ] }
+    - { role: infra-role-smart-metrics,       tags: [ smart-metrics ] }
+    - { role: redirect-ports,                 tags: [ redirect-ports ] }
+    - { role: get-geth-api-urls,              tags: [ get-geth-api-urls, beacon-node ] }
+    - { role: nimbus-era-files,               tags: [ nimbus-era-files ] }
+    - { role: infra-role-nimbus-light-client, tags: [ nimbus-light-client ] }
   tasks:
     - include_role:
         name: infra-role-beacon-node-linux

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -119,3 +119,8 @@
 - name: infra-role-nimbus-bench-eth1
   src: git@github.com:status-im/infra-role-nimbus-bench-eth1.git
   version: d94f021d3338282c17b7674289e4b876eff650ff
+
+- name: infra-role-nimbus-light-client
+  src: git@github.com:status-im/infra-role-nimbus-light-client.git
+  version: f33cdd51dfb7549ecd2c70d23e11e2ba08be7570
+


### PR DESCRIPTION
This PR enables running [Nimbus Light Client](https://nimbus.guide/el-light-client.html#__tabbed_6_1) by using newly created role [infra-role-nimbus-light-client](https://github.com/status-im/infra-role-nimbus-light-client).

in stand alone mode without EL client.

Ref:
- https://github.com/status-im/infra-nimbus/issues/101