### PR TITLE
Migrate era files from /data to /docker on Holesky fleet

### DIFF
--- a/ansible/group_vars/nimbus.holesky.yml
+++ b/ansible/group_vars/nimbus.holesky.yml
@@ -173,7 +173,7 @@ dist_validators_repo_ssh_key: '{{lookup("vault", "dist-validators/deploy-key", f
 
 # ERA files geneartion ---------------------------------------------------------
 nimbus_era_files_timer_enabled: '{{ (nodes_layout[inventory_hostname]|length) > 1 }}'
-nimbus_era_files_timer_path: '/data/era'
+nimbus_era_files_timer_path: '/docker/era'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/data/db'
 nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/repo/build/ncli_db'

--- a/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
+++ b/ansible/host_vars/geth-01.ih-eu-mda1.nimbus.holesky.yml
@@ -20,7 +20,7 @@ redirect_ports:
 
 # Era files hosting
 era_files_domain: 'holesky.era.nimbus.team'
-era_files_path: '/data/era'
+era_files_path: '/docker/era'
 
 # CloudFlare Origin certificates
 origin_certs:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,7 +26,7 @@
 
 - name: infra-role-oauth-proxy
   src: git@github.com:status-im/infra-role-oauth-proxy.git
-  version: d811225c9d0a64f5e73c1f70585d190be7def2c9
+  version: 7ce78de798ee8c1e4ecd8c0e6d23d86889d57839
 
 - name: infra-role-consul-service
   src: git@github.com:status-im/infra-role-consul-service.git
@@ -46,7 +46,7 @@
 
 - name: infra-role-validator-client
   src: git@github.com:status-im/infra-role-validator-client.git
-  version: 851e41dcf58ef14c33b2bd7f11b985327adbe391
+  version: 7750aed23197d8d931bd2a28af6a0673130fe97f
 
 - name: infra-role-nimbus-eth1
   src: git@github.com:status-im/infra-role-nimbus-eth1.git
@@ -62,11 +62,11 @@
 
 - name: infra-role-dist-validators
   src: git@github.com:status-im/infra-role-dist-validators.git
-  version: e3a4c34ebe4f1eeb95ad8d692b1ae25ea454cf99
+  version: 95a5de787aef58712121d2ac6c0bd97b6948baec
 
 - name: infra-role-rocketpool
   src: git@github.com:status-im/infra-role-rocketpool.git
-  version: c86d05fee3880d79e90c373cd57d9b0b00da5bc8
+  version: 5af21f2dec46cdfa9b1a5d7e26c56300088ae2d7
 
 - name: infra-role-winsw
   src: git@github.com:status-im/infra-role-winsw.git
@@ -74,11 +74,11 @@
 
 - name: infra-role-kibana
   src: git@github.com:status-im/infra-role-kibana.git
-  version: 11438c28906078ff8d47563b169926b5c2a89b96
+  version: b2b172ca6dbf3badbf5f8f77d48173a40cf04e7a
 
 - name: infra-role-elasticsearch
   src: git@github.com:status-im/infra-role-elasticsearch.git
-  version: d9dc779dccd879b429a4e808b463fb403ba5753f
+  version: aedab4dae99971d1c1add9ac6b192c26b7216210
 
 - name: infra-role-elasticsearch-lb
   src: git@github.com:status-im/infra-role-elasticsearch-lb.git
@@ -94,19 +94,19 @@
 
 - name: infra-role-geth
   src: git@github.com:status-im/infra-role-geth.git
-  version: 31cb16cb450928fb74693327681d01bb4e297bb8
+  version: e1aa94f70601a1fbd200cf46eebd15ab846b2d99
 
 - name: infra-role-geth-exporter
   src: git@github.com:status-im/infra-role-geth-exporter.git
-  version: 0859bd5b4a5010a7377c01ea3b4bb26195a594f4
+  version: 468d6b531dcd6369f353d53d45599e66ff8d91ce
 
 - name: infra-role-erigon
   src: git@github.com:status-im/infra-role-erigon.git
-  version: ab5db3a8ae20109c0664a1324944803a30167cae
+  version: 6df4916cd88f5a5f9f65f8d648eb4341694e47b9
 
 - name: infra-role-nethermind
   src: git@github.com:status-im/infra-role-nethermind.git
-  version: e8ae47f80050058c4afdc4227a6b25cf9bff31ac
+  version: c791097a0fcae46e21e4702454919ae25a5da832
 
 - name: infra-role-smart-metrics
   src: git@github.com:status-im/infra-role-smart-metrics.git
@@ -118,4 +118,4 @@
 
 - name: infra-role-nimbus-bench-eth1
   src: git@github.com:status-im/infra-role-nimbus-bench-eth1.git
-  version: ed5059de24c54ab928f390640f9a9a7649753e12
+  version: d94f021d3338282c17b7674289e4b876eff650ff

--- a/ansible/roles/nimbus-era-files/defaults/main.yml
+++ b/ansible/roles/nimbus-era-files/defaults/main.yml
@@ -3,7 +3,7 @@ nimbus_era_files_timer_name: 'nimbus-era-files'
 nimbus_era_files_timer_update_name: '{{ nimbus_era_files_timer_name }}-update'
 nimbus_era_files_timer_verify_name: '{{ nimbus_era_files_timer_name }}-verify'
 nimbus_era_files_timer_enabled: true
-nimbus_era_files_timer_path: '/data/era'
+nimbus_era_files_timer_path: '/docker/era'
 nimbus_era_files_timer_user: 'nimbus'
 nimbus_era_files_timer_group: 'staff'
 nimbus_era_files_timer_frequency: 'weekly'


### PR DESCRIPTION
- migrate the files and ensure they have right permissions
- update the timers for era files
- update nginx config for public hosting
- update Nimbus ETH1 Nodes with new era path