### PR TITLE
portal_bridge: Disable gossip of latest history content

### DIFF
--- a/ansible/group_vars/nimbus.fluffy.yml
+++ b/ansible/group_vars/nimbus.fluffy.yml
@@ -28,7 +28,7 @@ portal_bridge_fluffy_listening_port: 19100
 portal_bridge_fluffy_metrics_port: 19200
 portal_bridge_service_name: 'nimbus-portal-bridge-history'
 portal_bridge_command: 'history'
-portal_bridge_latest: true
+portal_bridge_latest: false
 portal_bridge_backfill: true
 portal_bridge_audit: true
 portal_bridge_era1_dir: '/era'


### PR DESCRIPTION
Clients will currently not accept this data anymore until they implement the new ephemeral headers type. Hence until that happens it is better to disable the gossip of this latest content.