### PR TITLE
hive: bootstrap node-01

### DIFF
--- a/ansible/inventory/test
+++ b/ansible/inventory/test
@@ -54,6 +54,7 @@ neth-04.ih-eu-mda1.nimbus.holesky ansible_host=185.181.229.100 data_center=ih-eu
 neth-05.ih-eu-mda1.nimbus.holesky ansible_host=185.181.229.103 data_center=ih-eu-mda1 dns_domain=status.im dns_entry=neth-05.ih-eu-mda1.nimbus.holesky.status.im env=nimbus region=eu-mda1 stage=holesky
 node-01.aws-eu-central-1a.dash.nimbus ansible_host=52.28.100.116 data_center=aws-eu-central-1a dns_domain=status.im dns_entry=node-01.aws-eu-central-1a.dash.nimbus.status.im env=dash region=eu-central-1a stage=nimbus
 node-01.do-ams3.nimbus.fluffy ansible_host=143.244.196.233 data_center=do-ams3 dns_domain=status.im dns_entry=node-01.do-ams3.nimbus.fluffy.status.im env=nimbus region=ams3 stage=fluffy
+node-01.he-eu-hel1.nimbus.hive ansible_host=65.109.22.181 data_center=he-eu-hel1 dns_domain=status.im dns_entry=node-01.he-eu-hel1.nimbus.hive.status.im env=nimbus region=eu-hel1 stage=hive
 store-01.he-eu-hel1.logs.nimbus ansible_host=65.108.226.62 data_center=he-eu-hel1 dns_domain=status.im dns_entry=store-01.he-eu-hel1.logs.nimbus.status.im env=logs region=eu-hel1 stage=nimbus
 store-02.he-eu-hel1.logs.nimbus ansible_host=65.109.62.247 data_center=he-eu-hel1 dns_domain=status.im dns_entry=store-02.he-eu-hel1.logs.nimbus.status.im env=logs region=eu-hel1 stage=nimbus
 store-03.he-eu-hel1.logs.nimbus ansible_host=65.109.49.101 data_center=he-eu-hel1 dns_domain=status.im dns_entry=store-03.he-eu-hel1.logs.nimbus.status.im env=logs region=eu-hel1 stage=nimbus
@@ -71,9 +72,13 @@ node-01.aws-eu-central-1a.dash.nimbus
 [do-ams3]
 node-01.do-ams3.nimbus.fluffy
 
+[ethereum_hive_testing]
+node-01.he-eu-hel1.nimbus.hive
+
 [he-eu-hel1]
 bench-01.he-eu-hel1.nimbus.eth1
 bench-02.he-eu-hel1.nimbus.eth1
+node-01.he-eu-hel1.nimbus.hive
 store-01.he-eu-hel1.logs.nimbus
 store-02.he-eu-hel1.logs.nimbus
 store-03.he-eu-hel1.logs.nimbus
@@ -238,6 +243,9 @@ node-01.do-ams3.nimbus.fluffy
 holesky-01.ih-eu-mda1.nimbus.geth
 holesky-02.ih-eu-mda1.nimbus.geth
 mainnet-01.aws-eu-central-1a.nimbus.geth
+
+[nimbus.hive]
+node-01.he-eu-hel1.nimbus.hive
 
 [nimbus.holesky]
 erigon-01.ih-eu-mda1.nimbus.holesky

--- a/hive.tf
+++ b/hive.tf
@@ -1,0 +1,23 @@
+/* Hetzner
+ * Dedicated AX41-NVMe Server
+ * Location: Finland, HEL1-DC5
+ * 1 x Primary IPv4
+ * 2 x 512 GB NVMe SSD
+ * 6 Core CPU
+ * 64 GB DDR4 RAM
+*/
+
+module "ethereum_hive_testing" {
+  source = "github.com/status-im/infra-tf-dummy-module"
+
+  name   = "node"
+  env    = "nimbus"
+  stage  = "hive"
+  group  = "ethereum_hive_testing"
+  region = "eu-hel1"
+  prefix = "he"
+
+  ips = [
+    "65.109.22.181", # "node-01.he-eu-hel1.nimbus.hive"
+  ]
+}


### PR DESCRIPTION
related: https://github.com/status-im/infra-nimbus/issues/228

bootstrap newly provisioned AX41-NVMe and added to `infra-nimbus` fleet.
The host is named : `node-01.he-eu-hel1.nimbus.hive`