### PR TITLE
holesky: remove 15 out of 30 hosts from fleet

### DIFF
--- a/ansible/group_vars/nimbus.holesky.yml
+++ b/ansible/group_vars/nimbus.holesky.yml
@@ -35,27 +35,6 @@ geth_expo_source_cont_name: '{{ geth_cont_name }}'
 geth_expo_source_data_path: '{{ geth_cont_vol }}/data'
 geth_expo_cont_port:  '{{ 9400 + (idx|int) + 1 }}'
 
-# Erigon -----------------------------------------------------------------------
-
-erigon_network_name: 'holesky'
-erigon_service_name: 'erigon-{{ erigon_network_name }}-{{ "%02d"|format(idx|int+1) }}'
-erigon_prune: 'hrtc' # TODO: Possibly wrong, verify.
-erigon_log_level: 'info'
-erigon_cont_mem_ratio: 0.15
-erigon_max_peers: 20
-erigon_miner_enabled: true
-erigon_mining_private_key: '{{lookup("vault", "testnet-wallet", field="private-key", stage="all")}}'
-# Ports
-erigon_metrics_enabled: true
-erigon_rpc_addr: '0.0.0.0'
-erigon_authrpc_addr: '0.0.0.0'
-erigon_port:              '{{ exec_layer_p2p_port }}'
-erigon_p2p_allowed_ports: ['{{ erigon_port }}', '{{ erigon_port|int + 1 }}']
-erigon_rpc_port:          '{{ exec_layer_rpc_port }}'
-erigon_metrics_port:      '{{ exec_layer_metrics_port }}'
-erigon_authrpc_port:      '{{ exec_layer_authrpc_port }}'
-erigon_authrpc_jwtsecret: '{{ beacon_node_exec_layer_jwt_secret }}'
-
 # Nethermind -------------------------------------------------------------------
 
 nethermind_network_name: 'holesky'

--- a/ansible/host_vars/geth-07.ih-eu-mda1.nimbus.holesky.yml
+++ b/ansible/host_vars/geth-07.ih-eu-mda1.nimbus.holesky.yml
@@ -1,9 +1,0 @@
----
-beacon_node_payload_builder_enabled: true
-beacon_node_payload_builder_url: 'http://localhost:{{ mev_boost_cont_port }}'
-validator_client_payload_builder_enabled: true
-
-mev_boost_enabled: true
-mev_boost_network: 'holesky'
-mev_boost_relays:
-  - 'https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz'

--- a/ansible/vars/layout/holesky.yml
+++ b/ansible/vars/layout/holesky.yml
@@ -14,116 +14,25 @@ nodes_layout:
     - { branch: 'unstable', start:     2, end:     3,  el: 'geth',      vc: false }
     - { branch: 'libp2p',   start:     3, end:     4,  el: 'geth',      vc: false }
 
-  'geth-03.ih-eu-mda1.nimbus.holesky': # 5 each
-    - { branch: 'stable',   start:     4, end:     9,  el: 'geth',      vc: true  }
-    - { branch: 'testing',  start:     9, end:    14,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:    14, end:    19,  el: 'geth',      vc: false }
-    - { branch: 'libp2p',   start:    19, end:    24,  el: 'geth',      vc: false }
+  'geth-03.ih-eu-mda1.nimbus.holesky': # 4 each
+    - { branch: 'stable',   start:     4, end:     8,  el: 'geth',      vc: true  }
+    - { branch: 'testing',  start:     8, end:    12,  el: 'geth',      vc: false }
+    - { branch: 'unstable', start:    12, end:    16,  el: 'geth',      vc: false }
+    - { branch: 'libp2p',   start:    16, end:    20,  el: 'geth',      vc: false }
 
-  'geth-04.ih-eu-mda1.nimbus.holesky': # 14 each
-    - { branch: 'stable',   start:    24, end:    38,  el: 'geth',      vc: true  }
-    - { branch: 'testing',  start:    38, end:    52,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:    52, end:    66,  el: 'geth',      vc: false }
-    - { branch: 'libp2p',   start:    66, end:    80,  el: 'geth',      vc: false }
+  'geth-04.ih-eu-mda1.nimbus.holesky': # 3245 each
+    - { branch: 'stable',   start:  20,   end:  3265,  el: 'geth',      vc: true  }
+    - { branch: 'testing',  start:  3265, end:  6510,  el: 'geth',      vc: false }
+    - { branch: 'unstable', start:  6510, end:  9755,  el: 'geth',      vc: false }
+    - { branch: 'libp2p',   start:  9755, end:  13000, el: 'geth',      vc: false }
 
-  'geth-05.ih-eu-mda1.nimbus.holesky': # 20 each
-    - { branch: 'stable',   start:    80, end:   100,  el: 'geth',      vc: true  }
-    - { branch: 'testing',  start:   100, end:   120,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:   120, end:   140,  el: 'geth',      vc: false }
-    - { branch: 'libp2p',   start:   140, end:   160,  el: 'geth',      vc: false }
-
-  'geth-06.ih-eu-mda1.nimbus.holesky': # 110 each
-    - { branch: 'stable',   start:   160, end:   270,  el: 'geth',      vc: true  }
-    - { branch: 'testing',  start:   270, end:   380,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:   380, end:   490,  el: 'geth',      vc: false }
-    - { branch: 'libp2p',   start:   490, end:   600,  el: 'geth',      vc: false }
-
-  'geth-07.ih-eu-mda1.nimbus.holesky': # 400 each
-    - { branch: 'stable',   start:   600, end:  1000,  el: 'geth',      vc: false }
-    - { branch: 'testing',  start:  1000, end:  1400,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:  1400, end:  1800,  el: 'geth',      vc: true,  payload_builder: true }
-    - { branch: 'libp2p',   start:  1800, end:  2200,  el: 'geth',      vc: false }
-
-  'geth-08.ih-eu-mda1.nimbus.holesky': # 700 each
-    - { branch: 'stable',   start:  2200, end:  2900,  el: 'geth',      vc: true  }
-    - { branch: 'testing',  start:  2900, end:  3600,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:  3600, end:  4300,  el: 'geth',      vc: false, payload_builder: true }
-    - { branch: 'libp2p',   start:  4300, end:  5000,  el: 'geth',      vc: false }
-
-  'geth-09.ih-eu-mda1.nimbus.holesky': # 2000 each
-    - { branch: 'stable',   start:  5000, end:  7000,  el: 'geth',      vc: false, payload_builder: true }
-    - { branch: 'testing',  start:  7000, end:  9000,  el: 'geth',      vc: false }
-    - { branch: 'unstable', start:  9000, end: 11000,  el: 'geth',      vc: true  }
-    - { branch: 'libp2p',   start: 11000, end: 13000,  el: 'geth',      vc: false }
-
-  'geth-10.ih-eu-mda1.nimbus.holesky': # 5000 each
+  'geth-05.ih-eu-mda1.nimbus.holesky': # 5000 each
     - { branch: 'stable',   start: 13000, end: 18000,  el: 'geth',      vc: true,  payload_builder: true }
     - { branch: 'testing',  start: 18000, end: 23000,  el: 'geth',      vc: false }
     - { branch: 'unstable', start: 23000, end: 28000,  el: 'geth',      vc: false }
     - { branch: 'libp2p',   start: 28000, end: 33000,  el: 'geth',      vc: false }
 
-  # Erigon ------------------------------------------------------------------------
-  'erigon-01.ih-eu-mda1.nimbus.holesky': # 0 each
-    - { branch: 'stable',                              el: 'erigon',     vc: false }
-    - { branch: 'testing',                             el: 'erigon',     vc: true  }
-    - { branch: 'unstable',                            el: 'erigon',     vc: false }
-    - { branch: 'libp2p',                              el: 'erigon',     vc: false }
-
-  'erigon-02.ih-eu-mda1.nimbus.holesky': # 1 each
-    - { branch: 'stable',   start: 33000, end: 33001,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 33001, end: 33002,  el: 'erigon',     vc: true  }
-    - { branch: 'unstable', start: 33002, end: 33003,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 33003, end: 33004,  el: 'erigon',     vc: false }
-
-  'erigon-03.ih-eu-mda1.nimbus.holesky': # 5 each
-    - { branch: 'stable',   start: 33004, end: 33009,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 33009, end: 33014,  el: 'erigon',     vc: true  }
-    - { branch: 'unstable', start: 33014, end: 33019,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 33019, end: 33024,  el: 'erigon',     vc: false }
-
-  'erigon-04.ih-eu-mda1.nimbus.holesky': # 14 each
-    - { branch: 'stable',   start: 33024, end: 33038,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 33038, end: 33052,  el: 'erigon',     vc: true  }
-    - { branch: 'unstable', start: 33052, end: 33066,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 33066, end: 33080,  el: 'erigon',     vc: false }
-
-  'erigon-05.ih-eu-mda1.nimbus.holesky': # 20 each
-    - { branch: 'stable',   start: 33080, end: 33100,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 33100, end: 33120,  el: 'erigon',     vc: true  }
-    - { branch: 'unstable', start: 33120, end: 33140,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 33140, end: 33160,  el: 'erigon',     vc: false }
-
-  'erigon-06.ih-eu-mda1.nimbus.holesky': # 110 each
-    - { branch: 'stable',   start: 33160, end: 33270,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 33270, end: 33380,  el: 'erigon',     vc: true  }
-    - { branch: 'unstable', start: 33380, end: 33490,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 33490, end: 33600,  el: 'erigon',     vc: false }
-
-  'erigon-07.ih-eu-mda1.nimbus.holesky': # 400 each
-    - { branch: 'stable',   start: 33600, end: 34000,  el: 'erigon',     vc: false, payload_builder: true }
-    - { branch: 'testing',  start: 34000, end: 34400,  el: 'erigon',     vc: false }
-    - { branch: 'unstable', start: 34400, end: 34800,  el: 'erigon',     vc: true  }
-    - { branch: 'libp2p',   start: 34800, end: 35200,  el: 'erigon',     vc: false }
-
-  'erigon-08.ih-eu-mda1.nimbus.holesky': # 700 each
-    - { branch: 'stable',   start: 35200, end: 35900,  el: 'erigon',     vc: true,  payload_builder: true }
-    - { branch: 'testing',  start: 35900, end: 36600,  el: 'erigon',     vc: false }
-    - { branch: 'unstable', start: 36600, end: 37300,  el: 'erigon',     vc: false }
-    - { branch: 'libp2p',   start: 37300, end: 38000,  el: 'erigon',     vc: false }
-
-  'erigon-09.ih-eu-mda1.nimbus.holesky': # 2000 each
-    - { branch: 'stable',   start: 38000, end: 40000,  el: 'erigon',     vc: true  }
-    - { branch: 'testing',  start: 40000, end: 42000,  el: 'erigon',     vc: false }
-    - { branch: 'unstable', start: 42000, end: 44000,  el: 'erigon',     vc: false, payload_builder: true }
-    - { branch: 'libp2p',   start: 44000, end: 46000,  el: 'erigon',     vc: false }
-
-  'erigon-10.ih-eu-mda1.nimbus.holesky': # 5000 each
-    - { branch: 'stable',   start: 46000, end: 51000,  el: 'erigon',     vc: false }
-    - { branch: 'testing',  start: 51000, end: 56000,  el: 'erigon',     vc: false }
-    - { branch: 'unstable', start: 56000, end: 61000,  el: 'erigon',     vc: true,  payload_builder: true }
-    - { branch: 'libp2p',   start: 61000, end: 66000,  el: 'erigon',     vc: false }
-
-  # Nethermind ---------------------------------------------------------------------
+  # Nimbus-eth1 ---------------------------------------------------------------------
   'nec-01.ih-eu-mda1.nimbus.holesky': # 0 each
     - { branch: 'stable',                              el: 'nec', vc: false }
     - { branch: 'testing',                             el: 'nec', vc: false }
@@ -131,53 +40,53 @@ nodes_layout:
     - { branch: 'libp2p',                              el: 'nec', vc: false }
 
   'nec-02.ih-eu-mda1.nimbus.holesky': # 1 each
-    - { branch: 'stable',   start: 66000, end: 66001,  el: 'nec', vc: false }
-    - { branch: 'testing',  start: 66001, end: 66002,  el: 'nec', vc: false }
-    - { branch: 'unstable', start: 66002, end: 66003,  el: 'nec', vc: true  }
-    - { branch: 'libp2p',   start: 66003, end: 66004,  el: 'nec', vc: false }
+    - { branch: 'stable',   start: 33000, end: 33001,  el: 'nec', vc: false }
+    - { branch: 'testing',  start: 33001, end: 33002,  el: 'nec', vc: false }
+    - { branch: 'unstable', start: 33002, end: 33003,  el: 'nec', vc: true  }
+    - { branch: 'libp2p',   start: 33003, end: 33004,  el: 'nec', vc: false }
 
-  'nec-03.ih-eu-mda1.nimbus.holesky': # 5 each
-    - { branch: 'stable',   start: 66004, end: 66009,  el: 'nec', vc: false }
-    - { branch: 'testing',  start: 66009, end: 66014,  el: 'nec', vc: false }
-    - { branch: 'unstable', start: 66014, end: 66019,  el: 'nec', vc: true  }
-    - { branch: 'libp2p',   start: 66019, end: 66024,  el: 'nec', vc: false }
+  'nec-03.ih-eu-mda1.nimbus.holesky': # 4 each
+    - { branch: 'stable',   start: 33004, end: 33008,  el: 'nec', vc: false }
+    - { branch: 'testing',  start: 33008, end: 33012,  el: 'nec', vc: false }
+    - { branch: 'unstable', start: 33012, end: 33016,  el: 'nec', vc: true  }
+    - { branch: 'libp2p',   start: 33016, end: 33020,  el: 'nec', vc: false }
 
-  'nec-04.ih-eu-mda1.nimbus.holesky': # 14 each
-    - { branch: 'stable',   start: 66024, end: 66038,  el: 'nec', vc: false }
-    - { branch: 'testing',  start: 66038, end: 66052,  el: 'nec', vc: false }
-    - { branch: 'unstable', start: 66052, end: 66066,  el: 'nec', vc: true  }
-    - { branch: 'libp2p',   start: 66066, end: 66080,  el: 'nec', vc: false }
+  'nec-04.ih-eu-mda1.nimbus.holesky': # 3245 each
+    - { branch: 'stable',   start: 33020, end: 36265,  el: 'nec', vc: false }
+    - { branch: 'testing',  start: 36265, end: 39510,  el: 'nec', vc: false }
+    - { branch: 'unstable', start: 39510, end: 42755,  el: 'nec', vc: true  }
+    - { branch: 'libp2p',   start: 42755, end: 46000,  el: 'nec', vc: false }
 
-  'nec-05.ih-eu-mda1.nimbus.holesky': # 20 each
-    - { branch: 'stable',   start: 66080, end: 66100,  el: 'nec', vc: false }
-    - { branch: 'testing',  start: 66100, end: 66120,  el: 'nec', vc: false }
-    - { branch: 'unstable', start: 66120, end: 66140,  el: 'nec', vc: true  }
-    - { branch: 'libp2p',   start: 66140, end: 66160,  el: 'nec', vc: false }
+  'nec-05.ih-eu-mda1.nimbus.holesky': # 5000 each
+    - { branch: 'stable',   start: 46000, end: 51000,  el: 'nec', vc: false }
+    - { branch: 'testing',  start: 51000, end: 56000,  el: 'nec', vc: false }
+    - { branch: 'unstable', start: 56000, end: 61000,  el: 'nec', vc: true  }
+    - { branch: 'libp2p',   start: 61000, end: 66000,  el: 'nec', vc: false }
 
   # Nethermind ---------------------------------------------------------------------
-  'neth-01.ih-eu-mda1.nimbus.holesky': # 110 each
-    - { branch: 'stable',   start: 66160, end: 66270,  el: 'nethermind', vc: false }
-    - { branch: 'testing',  start: 66270, end: 66380,  el: 'nethermind', vc: false }
-    - { branch: 'unstable', start: 66380, end: 66490,  el: 'nethermind', vc: true  }
-    - { branch: 'libp2p',   start: 66490, end: 66600,  el: 'nethermind', vc: false }
+  'neth-01.ih-eu-mda1.nimbus.holesky': # 0 each
+    - { branch: 'stable',                              el: 'nethermind', vc: false }
+    - { branch: 'testing',                             el: 'nethermind', vc: false }
+    - { branch: 'unstable',                            el: 'nethermind', vc: true  }
+    - { branch: 'libp2p',                              el: 'nethermind', vc: false }
 
-  'neth-02.ih-eu-mda1.nimbus.holesky': # 400 each
-    - { branch: 'stable',   start: 66600, end: 67000,  el: 'nethermind', vc: true,  payload_builder: true }
-    - { branch: 'testing',  start: 67000, end: 67400,  el: 'nethermind', vc: false }
-    - { branch: 'unstable', start: 67400, end: 67800,  el: 'nethermind', vc: false }
-    - { branch: 'libp2p',   start: 67800, end: 68200,  el: 'nethermind', vc: false }
+  'neth-02.ih-eu-mda1.nimbus.holesky': # 1 each
+    - { branch: 'stable',   start: 66000, end: 66001,  el: 'nethermind', vc: true,  payload_builder: true }
+    - { branch: 'testing',  start: 66001, end: 66002,  el: 'nethermind', vc: false }
+    - { branch: 'unstable', start: 66002, end: 66003,  el: 'nethermind', vc: false }
+    - { branch: 'libp2p',   start: 66003, end: 66004,  el: 'nethermind', vc: false }
 
-  'neth-03.ih-eu-mda1.nimbus.holesky': # 700 each
-    - { branch: 'stable',   start: 68200, end: 68900,  el: 'nethermind', vc: true  }
-    - { branch: 'testing',  start: 68900, end: 69600,  el: 'nethermind', vc: false }
-    - { branch: 'unstable', start: 69600, end: 70300,  el: 'nethermind', vc: true,  payload_builder: true }
-    - { branch: 'libp2p',   start: 70300, end: 71000,  el: 'nethermind', vc: false }
+  'neth-03.ih-eu-mda1.nimbus.holesky': # 4 each
+    - { branch: 'stable',   start: 66004, end: 66008,  el: 'nethermind', vc: true  }
+    - { branch: 'testing',  start: 66008, end: 66012,  el: 'nethermind', vc: false }
+    - { branch: 'unstable', start: 66012, end: 66016,  el: 'nethermind', vc: true,  payload_builder: true }
+    - { branch: 'libp2p',   start: 66016, end: 66020,  el: 'nethermind', vc: false }
 
-  'neth-04.ih-eu-mda1.nimbus.holesky': # 2000 each
-    - { branch: 'stable',   start: 71000, end: 73000,  el: 'nethermind', vc: false }
-    - { branch: 'testing',  start: 73000, end: 75000,  el: 'nethermind', vc: false }
-    - { branch: 'unstable', start: 75000, end: 77000,  el: 'nethermind', vc: true,  payload_builder: true }
-    - { branch: 'libp2p',   start: 77000, end: 79000,  el: 'nethermind', vc: false }
+  'neth-04.ih-eu-mda1.nimbus.holesky': # 3245 each
+    - { branch: 'stable',   start: 66020, end: 69265,  el: 'nethermind', vc: false }
+    - { branch: 'testing',  start: 69265, end: 72510,  el: 'nethermind', vc: false }
+    - { branch: 'unstable', start: 72510, end: 75755,  el: 'nethermind', vc: true,  payload_builder: true }
+    - { branch: 'libp2p',   start: 75755, end: 79000,  el: 'nethermind', vc: false }
 
   'neth-05.ih-eu-mda1.nimbus.holesky': # 5000 each
     - { branch: 'stable',   start: 79000, end: 84000,  el: 'nethermind', vc: false, payload_builder: true }

--- a/holesky.tf
+++ b/holesky.tf
@@ -14,35 +14,6 @@ module "nimbus_nodes_holesky_innova_geth" {
     "194.33.40.82",    # geth-03.ih-eu-mda1.nimbus.holesky
     "194.33.40.107",   # geth-04.ih-eu-mda1.nimbus.holesky
     "194.33.40.129",   # geth-05.ih-eu-mda1.nimbus.holesky
-    "194.33.40.130",   # geth-06.ih-eu-mda1.nimbus.holesky
-    "194.33.40.131",   # geth-07.ih-eu-mda1.nimbus.holesky
-    "194.33.40.140",   # geth-08.ih-eu-mda1.nimbus.holesky
-    "194.33.40.141",   # geth-09.ih-eu-mda1.nimbus.holesky
-    "194.33.40.147",   # geth-10.ih-eu-mda1.nimbus.holesky
-  ]
-}
-
-module "nimbus_nodes_holesky_innova_erigon" {
-  source = "github.com/status-im/infra-tf-dummy-module"
-
-  name   = "erigon"
-  env    = "nimbus"
-  stage  = "holesky"
-  group  = "nimbus-holesky-erigon"
-  region = "eu-mda1"
-  prefix = "ih"
-
-  ips = [
-    "194.33.40.148",   # erigon-01.ih-eu-mda1.nimbus.holesky
-    "194.33.40.149",   # erigon-02.ih-eu-mda1.nimbus.holesky
-    "194.33.40.151",   # erigon-03.ih-eu-mda1.nimbus.holesky
-    "194.33.40.157",   # erigon-04.ih-eu-mda1.nimbus.holesky
-    "194.33.40.241",   # erigon-05.ih-eu-mda1.nimbus.holesky
-    "194.33.40.242",   # erigon-06.ih-eu-mda1.nimbus.holesky
-    "194.33.40.243",   # erigon-07.ih-eu-mda1.nimbus.holesky
-    "194.33.40.244",   # erigon-08.ih-eu-mda1.nimbus.holesky
-    "194.33.40.245",   # erigon-09.ih-eu-mda1.nimbus.holesky
-    "194.33.40.246",   # erigon-10.ih-eu-mda1.nimbus.holesky
   ]
 }
 


### PR DESCRIPTION
- free-up half of hosts from Holesky fleet for running `Hoodi`
- dropping `erigon` EL since we are not going to run it for now on `Hoodi` testnet

Ref.:
- https://github.com/status-im/infra-nimbus/issues/239