### PR TITLE
nimbus.mainnet: close libp2p ports

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -124,9 +124,11 @@ beacon_node_max_peers: '{{ node.get("max_peers", 320) }}'
 # test mainnet nimbus with closed libp2p port
 beacon_node_closed_libp2p_ports: >-
   {%- set closed_ports = [] -%}
-  {%- for config in nodes_layout[inventory_hostname] if config.get('close_libp2p_port', false) -%}
-    {%- set port = 9000 + loop.index0 + 1 -%}
-    {%- set _ = closed_ports.append(port|string) -%}
+  {%- for config in nodes_layout[inventory_hostname] -%}
+    {%- if config.get('close_libp2p_port', false) -%}
+      {%- set port = 9000 + loop.index -%}
+      {%- set _ = closed_ports.append(port|string) -%}
+    {%- endif -%}
   {%- endfor -%}
   {{ closed_ports|join(',') }}
 # Excellent stress test and good service to the community.

--- a/ansible/vars/layout/mainnet.yml
+++ b/ansible/vars/layout/mainnet.yml
@@ -16,10 +16,10 @@ nodes_layout:
     - { branch: 'libp2p'              }
 
   'nec-02.ih-eu-mda1.nimbus.mainnet':
-    - { branch: 'stable',   el: 'nec' }
-    - { branch: 'testing',            }
-    - { branch: 'unstable', el: 'nec' }
-    - { branch: 'libp2p'              }
+    - { branch: 'stable',   el: 'nec'              }
+    - { branch: 'testing', close_libp2p_port: true }
+    - { branch: 'unstable', el: 'nec'              }
+    - { branch: 'libp2p'                           }
 
   'nec-03.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   el: 'nec' }
@@ -28,10 +28,10 @@ nodes_layout:
     - { branch: 'libp2p'              }
 
   'erigon-01.ih-eu-mda1.nimbus.mainnet':
-    - { branch: 'stable',   el: 'erigon' }
-    - { branch: 'testing'                }
-    - { branch: 'unstable', el: 'erigon' }
-    - { branch: 'libp2p'                 }
+    - { branch: 'stable',   el: 'erigon'            }
+    - { branch: 'testing',  close_libp2p_port: true }
+    - { branch: 'unstable', el: 'erigon'            }
+    - { branch: 'libp2p'                            }
 
   'erigon-02.ih-eu-mda1.nimbus.mainnet':
     - { branch: 'stable',   el: 'erigon' }


### PR DESCRIPTION
In previous filtering, loop was only iterating over configs where `close_libp2p_port` is true.

Close `tcp` and `udp` port for `testing` branch on:
- `nec-02.ih-eu-mda1.nimbus.mainnet`
- `erigon-01.ih-eu-mda1.nimbus.mainnet`

https://github.com/status-im/infra-nimbus/issues/212