### PR TITLE
mainnet: restore wildcard REST API origin

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -113,6 +113,8 @@ beacon_node_exec_layer_urls: ['http://localhost:{{ rpc_snooper_service_port if n
 beacon_node_exec_layer_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Suggests it to the Execution Layer client.
 beacon_node_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
+# Allow cross-origin request for public API endpoints.
+beacon_node_rest_allow_origin: '{{ "*" if node.get("public_api") else "" }}'
 # Windows service user
 beacon_node_service_user_pass: '{{lookup("vault", "windows-service-user", field="password", stage="all")}}'
 # MEV Payload Builder

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -108,6 +108,8 @@ beacon_node_validator_monitor_details: '{{ node.public_api is not defined or not
 beacon_node_exec_layer_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 beacon_node_exec_layer_urls_local: ['http://localhost:{{ exec_layer_authrpc_port }}']
 beacon_node_exec_layer_urls: '{{ beacon_node_exec_layer_urls_local if node.get("el") else [] }}'
+# Allow cross-origin request for public API endpoints.
+beacon_node_rest_allow_origin: '{{ "*" if node.get("public_api") else "" }}'
 # Light client data
 beacon_node_light_client_data_enabled: '{{ (node.public_api is defined and node.public_api) }}'
 beacon_node_light_client_data_serve: true
@@ -136,9 +138,6 @@ beacon_node_closed_libp2p_ports: >-
   {{ closed_ports|join(',') }}
 # Excellent stress test and good service to the community.
 beacon_node_subscribe_all: true
-# FIXME: Temporary test to debug REST API timeout issues.
-# https://github.com/status-im/nimbus-eth2/issues/5838
-#beacon_node_rest_allow_origin: '{{ "*" if node.get("public_api") else "" }}'
 
 # Reduce Consul alerts sensitivity
 beacon_node_consul_check_disabled: '{{ node.get("public_api", false) }}'

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -47,6 +47,8 @@ beacon_node_exec_layer_urls: ['http://localhost:{{ exec_layer_authrpc_port }}']
 beacon_node_exec_layer_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 # Suggests it to the Execution Layer client.
 beacon_node_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
+# Allow cross-origin request for public API endpoints.
+beacon_node_rest_allow_origin: '{{ "*" if node.get("public_api") else "" }}'
 # Validators from nimbus-private repo¬
 beacon_node_dist_validators_enabled: '{{ node.start is defined and node.end is defined }}'
 beacon_node_dist_validators_start: '{{ node.vc | ternary(0, node.start) | mandatory }}'


### PR DESCRIPTION
Problems that originally led to the wildcard origin being disabled in cb5176502f2dbe7d2225dd0223f4ee0cf24a0ee5 seem to have been resolved:
- https://github.com/status-im/nimbus-eth2/issues/5838