### PR TITLE
nimbus.mainnet: switch libp2p nodes to use syncv3 branch

### DIFF
--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -93,7 +93,7 @@ beacon_node_cores_per_node: '{{ (ansible_processor_vcpus / nodes_layout[inventor
 beacon_node_threads: '{{ (node.branch == "libp2p") | ternary(1, beacon_node_cores_per_node) }}'
 # We map short names to branches to avoid too long service names.
 node_name_to_branch_map:
-  libp2p: 'nim-libp2p-auto-bump-unstable'
+  libp2p: 'syncv3'
 # Builds
 beacon_node_update_build_targets: ['nimbus_beacon_node', 'ncli_db']
 beacon_node_update_build: '{{ beacon_node_repo_branch != "stable" }}'
@@ -147,7 +147,8 @@ beacon_node_consul_failures_before_critical: 180 # 3h
 
 # Checkpoint Sync
 beacon_node_resync_enabled: true
-beacon_node_resync_timer_enabled: false
+beacon_node_resync_timer_enabled: '{{ node.branch == "libp2p" }}' # TEMP: syncv3 testing
+beacon_node_resync_timer_frequency: 'weekly'
 beacon_node_resync_timer_trusted_api_url: 'http://localhost:{{ beacon_node_rest_port_base + 1 }}/' # stable
 
 # ERA files geneartion.

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -69,10 +69,6 @@ nimbus_eth1_metrics_address: '0.0.0.0'
 # API secert
 nimbus_eth1_jwt_secret: '{{ beacon_node_exec_layer_jwt_secret }}'
 
-# We map short names to branches to avoid too long service names.
-node_name_to_branch_map:
-  libp2p: 'nim-libp2p-auto-bump-unstable'
-
 # Beacon Nodes
 beacon_node_service_name: 'beacon-node-{{ beacon_node_network }}-{{ node.branch }}'
 beacon_node_network: 'sepolia'


### PR DESCRIPTION
Part of testing of new syncing algorithm:
- https://github.com/status-im/infra-nimbus/issues/265
- https://github.com/status-im/nimbus-eth2/pull/7578