### PR TITLE
hoodi: install clang18 using nix on macos

### DIFF
--- a/ansible/host_vars/macm2-01.ih-eu-mda1.nimbus.hoodi.yml
+++ b/ansible/host_vars/macm2-01.ih-eu-mda1.nimbus.hoodi.yml
@@ -3,3 +3,6 @@
 bootstrap__admin_pass: '{{lookup("passwordstore", "hosts/macos/admin/pass")}}'
 # No ELs available for MacOS right now.
 beacon_node_exec_layer_urls: []
+
+bootstrap__nix_extra_packages:
+  - llvmPackages_18.clang


### PR DESCRIPTION
Referenced issue:
* https://github.com/status-im/infra-role-bootstrap-macos/pull/14