### PR TITLE
portal: add appropriate timeouts for health check

### DIFF
--- a/ansible/group_vars/nimbus.portal.yml
+++ b/ansible/group_vars/nimbus.portal.yml
@@ -83,6 +83,12 @@ nimbus_eth1_http_port:        8545
 nimbus_eth1_metrics_port:     9093
 nimbus_eth1_engine_http_port: 8550
 nimbus_eth1_metrics_address: '0.0.0.0'
+# Consul healthchecks
+nimbus_eth1_consul_check_interval: '60s'
+nimbus_eth1_consul_check_timeout: '10s'
+nimbus_eth1_consul_success_before_passing:   60 # 1h
+nimbus_eth1_consul_failures_before_warning: 120 # 2h
+nimbus_eth1_consul_failures_before_critical: 180 # 3h
 # API secert
 nimbus_eth1_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stage="all")}}'
 


### PR DESCRIPTION
## Summary

Otherwise portal nodes are flapping.
I checked on host and the success returns 1.

<img width="995" height="396" alt="Screenshot 2026-03-27 at 1 13 15 PM" src="https://github.com/user-attachments/assets/dad41c69-08cb-41f9-93a7-0ec38c5bd9d8" />


they just need appropriate timeout to be set via group vars.

Current config is this : 

```json
metal-02% sudo cat service_nimbus_eth1_mainnet_master.json | jq '.services[].checks[]'
{
  "id": "nimbus-eth1-mainnet-master-health",
  "name": "nimbus-eth1-mainnet-master-health Script check",
  "args": [
    "/data/nimbus-eth1-mainnet-master/rpc.sh",
    "eth_syncing"
  ],
  "interval": "60s",
  "timeout": "5s",
  "success_before_passing": 1,
  "failures_before_warning": 3,
  "failures_before_critical": 5
}
{
  "id": "nimbus-eth1-mainnet-master-metrics-health",
  "name": "nimbus-eth1-mainnet-master-metrics-health HTTP check",
  "http": "http://localhost:9093/health",
  "method": "GET",
  "tls_skip_verify": false,
  "header": {},
  "interval": "60s",
  "timeout": "5s",
  "success_before_passing": 0,
  "failures_before_warning": 1,
  "failures_before_critical": 2
}
```