### PR TITLE
ansible: add branch_filter to limit playbook runs by branch

### DIFF
--- a/ansible/filter_plugins/branch_filter.py
+++ b/ansible/filter_plugins/branch_filter.py
@@ -1,0 +1,32 @@
+from jinja2.runtime import Undefined
+
+
+def filter_by_branch(nodes, branch=None):
+    """Filter list of node entries by branch name(s).
+
+    Used to limit Ansible playbook runs to a single branch (or subset of branches)
+    instead of looping through all entries in nodes_layout.
+
+    Usage in playbook:
+        with_items: "{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}"
+
+    Usage on CLI:
+        ansible-playbook ansible/hoodi.yml -l <host> -e branch_filter=libp2p
+        ansible-playbook ansible/hoodi.yml -l <host> -e 'branch_filter=["libp2p","unstable"]'
+        ansible-playbookansible/hoodi.yml -l <host> # no filter, loops through all branches
+
+    Accepts a single branch as string, list of branches, or None/undefined
+    (returns all nodes unchanged).
+    """
+    if branch is None or isinstance(branch, Undefined):
+        return nodes
+    if isinstance(branch, str):
+        branch = [branch]
+    return [n for n in nodes if n.get('branch') in branch]
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'filter_by_branch': filter_by_branch,
+        }

--- a/ansible/hoodi.yml
+++ b/ansible/hoodi.yml
@@ -1,4 +1,5 @@
 ---
+# Use `-e branch_filter=<branch>` to limit runs to a single branch (default: all branches).
 - name: Verify Ansible versions
   hosts: all
   tags: always
@@ -49,21 +50,21 @@
         apply:
           tags: always
       tags: [ rpc-snooper ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
     - include_role:
         name: infra-role-beacon-node-linux
         apply:
           tags: always
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
     - include_role:
         name: infra-role-validator-client
         apply:
           tags: always
       tags: [ validator-client ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       when: validator_client_service_enabled
       loop_control: { loop_var: node, index_var: idx }
 
@@ -80,7 +81,7 @@
           tags: always
       tags: [ geth ]
       when: node.el == "geth"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
     - include_role:
@@ -89,7 +90,7 @@
           tags: always
       tags: [ geth-exporter ]
       when: node.el == "geth"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Hoodi Nethermind Nodes
@@ -104,7 +105,7 @@
           tags: always
       tags: [ nethermind ]
       when: node.el == "nethermind"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Hoodi Nimbus ETH1 Nodes
@@ -121,7 +122,7 @@
       when:
         - "'el' in node"
         - node.el == "nec"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Hoodi MacOS Beacon Nodes
@@ -135,7 +136,7 @@
         apply:
           tags: always
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Hoodi Windows Beacon Nodes
@@ -150,5 +151,5 @@
         apply:
           tags: always
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -1,4 +1,5 @@
 ---
+# Use `-e branch_filter=<branch>` to limit runs to a single branch (default: all branches).
 - name: 'Verify Ansible versions'
   hosts: all
   tags: always
@@ -35,7 +36,7 @@
         name: infra-role-beacon-node-linux
         apply: { tags: always }
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
         index_var: idx
@@ -72,7 +73,7 @@
         name: infra-role-beacon-node-linux
         apply: { tags: always }
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
         index_var: idx
@@ -91,7 +92,7 @@
       when:
         - "'el' in node"
         - node.el == "geth"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
     - include_role:
@@ -102,7 +103,7 @@
       when:
         - "'el' in node"
         - node.el == "geth"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Mainnet Erigon Nodes
@@ -119,7 +120,7 @@
       when:
         - "'el' in node"
         - node.el == "erigon"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
 - name: Deploy Mainnet Nimbus ETH1 Nodes
@@ -136,5 +137,5 @@
       when:
         - "'el' in node"
         - node.el == "nec"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }

--- a/ansible/sepolia.yml
+++ b/ansible/sepolia.yml
@@ -1,4 +1,5 @@
 ---
+# Use `-e branch_filter=<branch>` to limit runs to a single branch (default: all branches).
 - name: Verify Ansible versions
   hosts: all
   tags: always
@@ -38,7 +39,7 @@
       when:
         - "'el' in node"
         - node.el == "nethermind"
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control: { loop_var: node, index_var: idx }
 
     - include_role:
@@ -46,7 +47,7 @@
         apply:
           tags: always
       tags: [ beacon-node ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
         index_var: idx
@@ -56,7 +57,7 @@
         apply:
           tags: always
       tags: [ validator-client ]
-      with_items: '{{ nodes_layout[inventory_hostname] }}'
+      with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       when: validator_client_service_enabled
       loop_control:
         loop_var: node


### PR DESCRIPTION
Used to limit Ansible playbook runs to a single branch (or subset of branches) instead of looping through all entries in nodes_layout.