### PR TITLE
ansible: fix for filter by branch plugin

### DIFF
--- a/ansible/filter_plugins/branch_filter.py
+++ b/ansible/filter_plugins/branch_filter.py
@@ -1,4 +1,5 @@
 from jinja2.runtime import Undefined
+import json
 
 
 def filter_by_branch(nodes, branch=None):
@@ -12,17 +13,26 @@ def filter_by_branch(nodes, branch=None):
 
     Usage on CLI:
         ansible-playbook ansible/hoodi.yml -l <host> -e branch_filter=libp2p
+        ansible-playbook ansible/hoodi.yml -l <host> -e branch_filter=libp2p,unstable
         ansible-playbook ansible/hoodi.yml -l <host> -e 'branch_filter=["libp2p","unstable"]'
-        ansible-playbookansible/hoodi.yml -l <host> # no filter, loops through all branches
+        ansible-playbook ansible/hoodi.yml -l <host> -e '{"branch_filter": ["libp2p","unstable"]}'
+        ansible-playbook ansible/hoodi.yml -l <host>  # no filter, loops through all branches
 
-    Accepts a single branch as string, list of branches, or None/undefined
-    (returns all nodes unchanged).
+    Accepts a single branch as string, comma-separated string, JSON list string,
+    native list, or None/undefined (returns all nodes unchanged).
+    All returned nodes include an _idx field with their original position in the list.
     """
     if branch is None or isinstance(branch, Undefined):
-        return nodes
+        return [dict(n, _idx=i) for i, n in enumerate(nodes)]
+
     if isinstance(branch, str):
-        branch = [branch]
-    return [n for n in nodes if n.get('branch') in branch]
+        try:
+            parsed = json.loads(branch)
+            branch = parsed if isinstance(parsed, list) else [branch]
+        except (json.JSONDecodeError, ValueError):
+            branch = [b.strip() for b in branch.split(',')]
+
+    return [dict(n, _idx=i) for i, n in enumerate(nodes) if n.get('branch') in branch]
 
 
 class FilterModule(object):

--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -6,11 +6,11 @@ mev_boost_relays:
   - 'https://0x98f0ef62f00780cf8eb06701a7d22725b9437d4768bb19b363e882ae87129945ec206ec2dc16933f31d983f8225772b6@hoodi.aestus.live'
   - 'https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.hoodi.blxrbdn.com'
 # Ports used for all 4 EL nodes as they are mutually exclusive.
-exec_layer_p2p_port:     '{{ 30303 + 3*idx|int + 1 }}'
-exec_layer_rpc_port:     '{{ 8545  +   idx|int + 1 }}'
-exec_layer_authrpc_port: '{{ 8551  +   idx|int + 1 }}'
-exec_layer_metrics_port: '{{ 6060  +   idx|int + 1 }}'
-exec_layer_snooper_port: '{{ 8700  +   idx|int + 1 }}'
+exec_layer_p2p_port:     '{{ 30303 + 3*node._idx|int + 1 }}'
+exec_layer_rpc_port:     '{{ 8545  +   node._idx|int + 1 }}'
+exec_layer_authrpc_port: '{{ 8551  +   node._idx|int + 1 }}'
+exec_layer_metrics_port: '{{ 6060  +   node._idx|int + 1 }}'
+exec_layer_snooper_port: '{{ 8700  +   node._idx|int + 1 }}'
 
 era_files_path: '/docker/era'
 
@@ -42,7 +42,7 @@ geth_metrics_port:    '{{ exec_layer_metrics_port }}'
 geth_expo_service_name: '{{ geth_service_name }}'
 geth_expo_source_cont_name: '{{ geth_cont_name }}'
 geth_expo_source_data_path: '{{ geth_cont_vol }}/data'
-geth_expo_cont_port:  '{{ 9400 + (idx|int) + 1 }}'
+geth_expo_cont_port:  '{{ 9400 + (node._idx|int) + 1 }}'
 
 # Nethermind -------------------------------------------------------------------
 
@@ -96,7 +96,7 @@ beacon_node_suggested_gas_limit: 60000000
 node_name_to_branch_map:
   libp2p: 'syncv3'
 # Builds
-beacon_node_update_frequency: '*-*-* {{ "%02d" | format(idx * 2) }}:00:00'
+beacon_node_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:00:00'
 beacon_node_update_build_nim_flags: >-
   -d:noSignalHandler
   {# Temporary for debugging of possible futures leak. #}
@@ -132,10 +132,10 @@ beacon_node_dist_validators_start: '{{ node.get("vc", false) | ternary(0, node.s
 beacon_node_dist_validators_end:   '{{ node.get("vc", false) | ternary(0, node.end)   | mandatory }}'
 # Ports
 beacon_node_rest_port_base: 9300
-beacon_node_rest_port:      '{{ beacon_node_rest_port_base + idx|int + 1 }}'
-beacon_node_discovery_port: '{{ 9000 + idx|int + 1 }}'
-beacon_node_listening_port: '{{ 9000 + idx|int + 1 }}'
-beacon_node_metrics_port:   '{{ 9200 + idx|int + 1 }}'
+beacon_node_rest_port:      '{{ beacon_node_rest_port_base + node._idx|int + 1 }}'
+beacon_node_discovery_port: '{{ 9000 + node._idx|int + 1 }}'
+beacon_node_listening_port: '{{ 9000 + node._idx|int + 1 }}'
+beacon_node_metrics_port:   '{{ 9200 + node._idx|int + 1 }}'
 beacon_node_rest_address:   '0.0.0.0'
 
 # Reduce Consul alerts sensitivity
@@ -151,7 +151,7 @@ beacon_node_consul_failures_before_critical: '{{ 720 if not node.get("public_api
 beacon_node_resync_enabled: true
 beacon_node_resync_timer_enabled: '{{ node.branch == "libp2p" }}' # TEMP: syncv3 testing
 beacon_node_resync_timer_frequency: 'weekly'
-beacon_node_resync_timer_trusted_api_url: '{{ beacon_node_resync_timer_trusted_api_urls[idx] }}'
+beacon_node_resync_timer_trusted_api_url: '{{ beacon_node_resync_timer_trusted_api_urls[node._idx] }}'
 beacon_node_resync_timer_trusted_api_urls:
   - 'https://checkpoint-sync.hoodi.ethpandaops.io/'
   - 'https://hoodi-checkpoint-sync.stakely.io/'
@@ -171,8 +171,8 @@ validator_client_beacon_node_urls: ['http://127.0.0.1:{{ beacon_node_rest_port }
 validator_client_repo_branch: '{{ beacon_node_repo_branch }}'
 validator_client_update_frequency: 'daily'
 # Ports
-validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
-validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
+validator_client_metrics_port:    '{{ 8108 + node._idx|int + 1 }}'
+validator_client_keymanager_port: '{{ 5052 + node._idx|int + 1 }}'
 # Suggests it to the Execution Layer client and the builder network.
 validator_client_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # Keymanager

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -4,10 +4,10 @@ bootstrap__extra_volume_path: '/docker'
 bootstrap__extra_volume_bind_path: null
 
 # Ports used for all 3 EL nodes as they are mutually exclusive.
-exec_layer_p2p_port:     '{{ 30303 + 3*idx|int + 1 }}'
-exec_layer_rpc_port:     '{{ 8545  +   idx|int + 1 }}'
-exec_layer_authrpc_port: '{{ 8551  +   idx|int + 1 }}'
-exec_layer_metrics_port: '{{ 6060  +   idx|int + 1 }}'
+exec_layer_p2p_port:     '{{ 30303 + 3*node._idx|int + 1 }}'
+exec_layer_rpc_port:     '{{ 8545  +   node._idx|int + 1 }}'
+exec_layer_authrpc_port: '{{ 8551  +   node._idx|int + 1 }}'
+exec_layer_metrics_port: '{{ 6060  +   node._idx|int + 1 }}'
 
 era_files_path: '/data/era'
 era1_files_path: '/data/era1'
@@ -38,7 +38,7 @@ geth_metrics_port:    '{{ exec_layer_metrics_port }}'
 geth_expo_service_name: '{{ geth_service_name }}'
 geth_expo_source_cont_name: '{{ geth_cont_name }}'
 geth_expo_source_data_path: '{{ geth_cont_vol }}/data'
-geth_expo_cont_port:  '{{ 9400 + (idx|int) + 1 }}'
+geth_expo_cont_port:  '{{ 9400 + (node._idx|int) + 1 }}'
 
 # Erigon -----------------------------------------------------------------------
 
@@ -100,7 +100,7 @@ node_name_to_branch_map:
 # Builds
 beacon_node_update_build_targets: ['nimbus_beacon_node', 'ncli_db']
 beacon_node_update_build: '{{ beacon_node_repo_branch != "stable" }}'
-beacon_node_update_frequency: '*-*-* {{ "%02d" | format(idx * 2) }}:00:00'
+beacon_node_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:00:00'
 # Monitoring
 beacon_node_validator_monitor_auto: true
 beacon_node_validator_monitor_details: '{{ node.public_api is not defined or not node.public_api }}'
@@ -119,10 +119,10 @@ light_client_network: 'mainnet'
 beacon_node_dist_validators_enabled: false
 # Ports
 beacon_node_rest_port_base: 9300
-beacon_node_rest_port:      '{{ beacon_node_rest_port_base + idx|int + 1 }}'
-beacon_node_discovery_port: '{{ 9000 + idx|int + 1 }}'
-beacon_node_listening_port: '{{ 9000 + idx|int + 1 }}'
-beacon_node_metrics_port:   '{{ 9200 + idx|int + 1 }}'
+beacon_node_rest_port:      '{{ beacon_node_rest_port_base + node._idx|int + 1 }}'
+beacon_node_discovery_port: '{{ 9000 + node._idx|int + 1 }}'
+beacon_node_listening_port: '{{ 9000 + node._idx|int + 1 }}'
+beacon_node_metrics_port:   '{{ 9200 + node._idx|int + 1 }}'
 beacon_node_rest_address:   '0.0.0.0'
 beacon_node_max_peers: '{{ node.get("max_peers", 320) }}'
 # Firewall

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -4,10 +4,10 @@ mev_boost_cont_tag: '1.10a5'
 mev_boost_relays:
   - 'https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-sepolia.flashbots.net'
 # Ports used for all 2 EL nodes as they are mutually exclusive.
-exec_layer_p2p_port:     '{{ 30303 + 3*idx|int + 1 }}'
-exec_layer_rpc_port:     '{{ 8545  +   idx|int + 1 }}'
-exec_layer_authrpc_port: '{{ 8551  +   idx|int + 1 }}'
-exec_layer_metrics_port: '{{ 6060  +   idx|int + 1 }}'
+exec_layer_p2p_port:     '{{ 30303 + 3*node._idx|int + 1 }}'
+exec_layer_rpc_port:     '{{ 8545  +   node._idx|int + 1 }}'
+exec_layer_authrpc_port: '{{ 8551  +   node._idx|int + 1 }}'
+exec_layer_metrics_port: '{{ 6060  +   node._idx|int + 1 }}'
 
 # Nethermind -------------------------------------------------------------------
 nethermind_network_name: 'sepolia'
@@ -36,7 +36,7 @@ beacon_node_suggested_gas_limit: 60000000
 beacon_node_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 beacon_node_payload_builder_url: 'http://localhost:{{ mev_boost_cont_port }}'
 # Updates
-beacon_node_update_frequency: '*-*-* {{ "%02d" | format(idx * 2) }}:00:00'
+beacon_node_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:00:00'
 beacon_node_update_build_nim_flags: '-d:noSignalHandler {{ node.get("nim_flags", "") }}'
 beacon_node_update_build_targets: ['nimbus_beacon_node', 'ncli_db']
 # Monitoring
@@ -55,10 +55,10 @@ beacon_node_dist_validators_start: '{{ node.vc | ternary(0, node.start) | mandat
 beacon_node_dist_validators_end:   '{{ node.vc | ternary(0, node.end)   | mandatory }}'
 # Ports
 beacon_node_rest_port_base: 9300
-beacon_node_discovery_port: '{{ 9000 + idx|int + 11 }}'
-beacon_node_listening_port: '{{ 9000 + idx|int + 11 }}'
-beacon_node_metrics_port:   '{{ 9200 + idx|int + 11 }}'
-beacon_node_rest_port:      '{{ beacon_node_rest_port_base + idx|int + 11 }}'
+beacon_node_discovery_port: '{{ 9000 + node._idx|int + 11 }}'
+beacon_node_listening_port: '{{ 9000 + node._idx|int + 11 }}'
+beacon_node_metrics_port:   '{{ 9200 + node._idx|int + 11 }}'
+beacon_node_rest_port:      '{{ beacon_node_rest_port_base + node._idx|int + 11 }}'
 beacon_node_rest_address:   '0.0.0.0'
 # Reduce Consul alerts sensitivity
 beacon_node_consul_check_disabled: '{{ node.get("public_api", false) }}'
@@ -87,8 +87,8 @@ validator_client_beacon_node_urls:
 validator_client_repo_branch: '{{ beacon_node_repo_branch }}'
 validator_client_update_frequency: 'daily'
 # Ports
-validator_client_metrics_port:    '{{ 8108 + idx|int + 1 }}'
-validator_client_keymanager_port: '{{ 5052 + idx|int + 1 }}'
+validator_client_metrics_port:    '{{ 8108 + node._idx|int + 1 }}'
+validator_client_keymanager_port: '{{ 5052 + node._idx|int + 1 }}'
 # Suggests it to the Execution Layer client and the builder network.
 validator_client_suggested_fee_recipient: '{{lookup("vault", "testnet-wallet", field="address", stage="all")}}'
 # Keymanager

--- a/ansible/hoodi.yml
+++ b/ansible/hoodi.yml
@@ -51,14 +51,14 @@
           tags: always
       tags: [ rpc-snooper ]
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node}
     - include_role:
         name: infra-role-beacon-node-linux
         apply:
           tags: always
       tags: [ beacon-node ]
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node}
     - include_role:
         name: infra-role-validator-client
         apply:
@@ -66,7 +66,7 @@
       tags: [ validator-client ]
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       when: validator_client_service_enabled
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node}
 
 - name: Deploy Hoodi Geth Nodes
   become: true
@@ -82,7 +82,7 @@
       tags: [ geth ]
       when: node.el == "geth"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
     - include_role:
         name: infra-role-geth-exporter
@@ -91,7 +91,7 @@
       tags: [ geth-exporter ]
       when: node.el == "geth"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Hoodi Nethermind Nodes
   become: true
@@ -106,7 +106,7 @@
       tags: [ nethermind ]
       when: node.el == "nethermind"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Hoodi Nimbus ETH1 Nodes
   become: true
@@ -123,7 +123,7 @@
         - "'el' in node"
         - node.el == "nec"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Hoodi MacOS Beacon Nodes
   become: true
@@ -137,7 +137,7 @@
           tags: always
       tags: [ beacon-node ]
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Hoodi Windows Beacon Nodes
   become: true
@@ -152,4 +152,4 @@
           tags: always
       tags: [ beacon-node ]
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }

--- a/ansible/mainnet.yml
+++ b/ansible/mainnet.yml
@@ -39,7 +39,6 @@
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
-        index_var: idx
 
 - name: Deploy mainnet linux beacon nodes
   become: true
@@ -76,7 +75,6 @@
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
-        index_var: idx
 
 - name: Deploy Mainnet Geth Nodes
   become: true
@@ -93,7 +91,7 @@
         - "'el' in node"
         - node.el == "geth"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
     - include_role:
         name: infra-role-geth-exporter
@@ -104,7 +102,7 @@
         - "'el' in node"
         - node.el == "geth"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Mainnet Erigon Nodes
   become: true
@@ -121,7 +119,7 @@
         - "'el' in node"
         - node.el == "erigon"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
 - name: Deploy Mainnet Nimbus ETH1 Nodes
   become: true
@@ -138,4 +136,4 @@
         - "'el' in node"
         - node.el == "nec"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }

--- a/ansible/purge-eth1.yml
+++ b/ansible/purge-eth1.yml
@@ -16,14 +16,14 @@
         name: '{{ nimbus_eth1_service_name }}.service'
         state: 'stopped'
       with_items: '{{ nodes_layout[inventory_hostname] }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
       when: node.get('el') == 'nec'
 
     - name: Purge Nimbus-Eth1 node data
       command: |
         rm -fr '{{ nimbus_eth1_service_path }}/data/shared_mainnet_0/nimbus/aristo'
       with_items: '{{ nodes_layout[inventory_hostname] }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
       when: node.get('el') == 'nec'
 
     - name: Starting Nimbus-Eth1 nodes
@@ -31,5 +31,5 @@
         name: '{{ nimbus_eth1_service_name }}.service'
         state: 'started'
       with_items: '{{ nodes_layout[inventory_hostname] }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
       when: node.get('el') == 'nec'

--- a/ansible/sepolia.yml
+++ b/ansible/sepolia.yml
@@ -40,7 +40,7 @@
         - "'el' in node"
         - node.el == "nethermind"
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
-      loop_control: { loop_var: node, index_var: idx }
+      loop_control: { loop_var: node }
 
     - include_role:
         name: infra-role-beacon-node-linux
@@ -50,7 +50,6 @@
       with_items: '{{ nodes_layout[inventory_hostname] | filter_by_branch(branch_filter) }}'
       loop_control:
         loop_var: node
-        index_var: idx
 
     - include_role:
         name: infra-role-validator-client
@@ -61,4 +60,3 @@
       when: validator_client_service_enabled
       loop_control:
         loop_var: node
-        index_var: idx


### PR DESCRIPTION
The filter didn't return the right index of the filtered branch, resulting in the clash in ports(tested on
geth-01.ih-eu-mda1.nimbus.hoodi). After applying the ansible playbook with -e branch_filter=testing, the service was started and then immediately shut down:
```
{"lvl":"FAT","ts":"2026-04-29 12:42:41.470+00:00","msg":"Could not start metrics HTTP server","topics":"beacnde","url":"http://0.0.0.0:9201/metrics","reason":"Metrics server returns an error: (98) Address already in use"}
```
Meaning the assigned index was 0. The same was for other ports.

I added also the option to pass filter in format: `-e branch_filter=testing,unstable` 