### PR TITLE
fleet variables: update macos and linux vars to reflect underlying role changes

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -158,6 +158,9 @@ beacon_node_resync_timer_trusted_api_urls:
   - 'https://beaconstate-hoodi.chainsafe.io/'
   - 'https://hoodi.beaconstate.ethstaker.cc/'
 
+# Nix - GCC11 for building BN
+beacon_node_nix_flake_target: "{{ 'beacon_node_gcc11' if node.branch == 'unstable' else 'beacon_node' }}"
+
 # Validator Client -------------------------------------------------------------
 
 validator_client_service_name: 'validator-client-{{ validator_client_network }}-{{ node.branch }}'
@@ -182,6 +185,8 @@ validator_client_keymanager_token: '{{lookup("vault", "validator-client", field=
 validator_client_dist_validators_enabled: '{{ beacon_node_dist_validators_enabled }}'
 validator_client_dist_validators_start: '{{ (not node.get("vc", false)) | ternary(0, node.start) | mandatory }}'
 validator_client_dist_validators_end:   '{{ (not node.get("vc", false)) | ternary(0, node.end)   | mandatory }}'
+# Nix - GCC11 for building VC
+validator_client_nix_flake_target: "{{ 'validator_client_gcc11' if node.branch == 'unstable' else 'validator_client' }}"
 
 # Dist validators
 dist_validators_repo_ssh_key: '{{lookup("vault", "dist-validators/deploy-key", field="private", stage="all")}}'

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -153,6 +153,9 @@ beacon_node_resync_timer_enabled: '{{ node.branch == "libp2p" }}' # TEMP: syncv3
 beacon_node_resync_timer_frequency: 'weekly'
 beacon_node_resync_timer_trusted_api_url: 'http://localhost:{{ beacon_node_rest_port_base + 1 }}/' # stable
 
+# Nix - GCC11 for building BN
+beacon_node_nix_flake_target: "{{ 'beacon_node_gcc11' if node.branch == 'unstable' else 'beacon_node' }}"
+
 # ERA files geneartion.
 nimbus_era_files_timer_enabled: '{{ (nodes_layout[inventory_hostname]|length) > 1 }}'
 nimbus_era_files_timer_path: '{{ era_files_path }}'

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -67,6 +67,8 @@ beacon_node_consul_check_timeout: '10s'
 beacon_node_consul_success_before_passing:    60 # 1h
 beacon_node_consul_failures_before_warning:  360 # 6h
 beacon_node_consul_failures_before_critical: 720 # 12h
+# Nix - GCC11 for building BN
+beacon_node_nix_flake_target: "{{ 'beacon_node_gcc11' if node.branch == 'unstable' else 'beacon_node' }}"
 
 # Validator Client -------------------------------------------------------------
 validator_client_service_name: 'validator-client-{{ validator_client_network }}-{{ node.branch }}'

--- a/ansible/host_vars/macm2-01.ih-eu-mda1.nimbus.hoodi.yml
+++ b/ansible/host_vars/macm2-01.ih-eu-mda1.nimbus.hoodi.yml
@@ -8,5 +8,5 @@ beacon_node_era_dir_path: '{{ beacon_node_data_path }}/era'
 # Avoid breaking Launchd timer format
 beacon_node_resync_timer_frequency: 604800
 
-bootstrap__nix_extra_packages:
+nix_extra_packages:
   - llvmPackages_18.clang


### PR DESCRIPTION
macos: the nix setup was extracted to a separate repo and variable naming changed
linux: the changes to BN and VC role deployment/update has changed and now we use nix, because of that as a request from Nimbus team we are compiling the executables with GCC11 - so far we can do that for unstable branch only but when the change in nimbus-eth2 propagates to other branches we will deploy it to the others in this fleet as well.