### PR TITLE
fleet: add nix-settings variables

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -209,6 +209,15 @@ rpc_snooper_suppress_paths: []
 # https://github.com/status-im/infra-misc/issues/301
 bootstrap__firewall_nftables: true
 
+# Nix Daemon settings
+nix_settings:
+  'build-users-group': 'nixbld'
+  'auto-allocate-uids': 'false'
+  'experimental-features': 'flakes nix-command auto-allocate-uids'
+  'download-buffer-size': '268435456'
+  'extra-substituters': 'https://nix-cache.status.im/''
+  'extra-trusted-public-keys': 'nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY='
+
 # Open Ports -------------------------------------------------------------------
 host_el_type: '{{ ansible_hostname|split("-")|first }}'
 open_ports_list:

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -168,6 +168,15 @@ nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-testi
 # https://github.com/status-im/infra-misc/issues/301
 bootstrap__firewall_nftables: true
 
+# Nix Daemon settings
+nix_settings:
+  'build-users-group': 'nixbld'
+  'auto-allocate-uids': 'false'
+  'experimental-features': 'flakes nix-command auto-allocate-uids'
+  'download-buffer-size': '268435456'
+  'extra-substituters': 'https://nix-cache.status.im/''
+  'extra-trusted-public-keys': 'nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY='
+
 # Open Ports
 host_el_type: '{{ ansible_hostname|split("-")|first }}'
 open_ports_list:

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -115,6 +115,15 @@ nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-unsta
 # https://github.com/status-im/infra-misc/issues/301
 bootstrap__firewall_nftables: true
 
+# Nix Daemon settings
+nix_settings:
+  'build-users-group': 'nixbld'
+  'auto-allocate-uids': 'false'
+  'experimental-features': 'flakes nix-command auto-allocate-uids'
+  'download-buffer-size': '268435456'
+  'extra-substituters': 'https://nix-cache.status.im/''
+  'extra-trusted-public-keys': 'nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY='
+
 # Open Ports
 host_el_type: 'EL node'
 open_ports_list:


### PR DESCRIPTION
Needed for nix cache to work when building the executables across fleet.

Referenced issue:
* https://github.com/status-im/infra-nimbus/issues/276