### PR TITLE
nimbus-era-files: add ncli_db update service

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -200,7 +200,6 @@ nimbus_era_files_timer_enabled: '{{ (nodes_layout[inventory_hostname]|length) > 
 nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/data/db'
-nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/bin/ncli_db'
 
 # RPC-snooper
 rpc_snooper_service_name: 'rpc-snooper-{{ beacon_node_network }}-{{ node.branch | mandatory }}'

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -162,7 +162,6 @@ nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 # FIXME: Not pretty, since hardcoded, but the simplest way to do it right now.
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-testing/data/db'
-nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-testing/bin/ncli_db'
 
 # Migrated to NFTables from IPTables.
 # https://github.com/status-im/infra-misc/issues/301

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -104,7 +104,6 @@ nimbus_era_files_timer_enabled: '{{ (nodes_layout[inventory_hostname]|length) > 
 nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/data/db'
-nimbus_era_files_nclidb_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/bin/ncli_db'
 
 # Migrated to NFTables from IPTables.
 # https://github.com/status-im/infra-misc/issues/301

--- a/ansible/roles/nimbus-era-files/README.md
+++ b/ansible/roles/nimbus-era-files/README.md
@@ -1,8 +1,10 @@
 # Description
 
-This role configures a Systemd timer which generates Nimbus ERA files weekly.
+This role configures Systemd timers for managing Nimbus beacon node ERA files:
 
-The purpose of those is to save space by sharing the same historical data between nodes.
+- **update** — generates ERA files weekly to save space by sharing the same historical data between nodes.
+- **verify** — checks the integrity of generated ERA files.
+- **ncli-db-update** — builds/updates the `ncli_db` executable from source via Nix. This is the binary used to generate the ERA files, so it's kept current on its own schedule.
 
 Read more about ERA files [here](https://github.com/status-im/nimbus-eth2/blob/unstable/docs/e2store.md#era-files).
 
@@ -12,10 +14,9 @@ Read more about ERA files [here](https://github.com/status-im/nimbus-eth2/blob/u
 nimbus_era_files_timer_name: 'nimbus-era-files'
 nimbus_era_files_timer_update_name: '{{ nimbus_era_files_timer_name }}-update'
 nimbus_era_files_timer_verify_name: '{{ nimbus_era_files_timer_name }}-verify'
-nimbus_era_files_timer_path: '/data/era'
-nimbus_era_files_nclidb_path: '/data/nimbus/bin/ncli_db'
-nimbus_era_files_db_path: '/data/nimbus/data/db'
-#nimbus_era_files_network: 'hoodi'
+nimbus_era_files_timer_path: '/docker/era'
+nimbus_era_files_db_path: '/data/nimbus/data/db'   # mandatory
+nimbus_era_files_network: 'hoodi'                  # mandatory
 ```
 
 # Management

--- a/ansible/roles/nimbus-era-files/defaults/main.yml
+++ b/ansible/roles/nimbus-era-files/defaults/main.yml
@@ -12,7 +12,21 @@ nimbus_era_files_timer_random_delay_sec: '{{ 60 * 60 * 12 }}'
 nimbus_era_files_timer_ionice_class: 'idle'
 nimbus_era_files_timer_script: '{{ nimbus_era_files_timer_path }}/update.sh'
 
+nimbus_era_files_nclidb_timer_name: 'nimbus-era-files-ncli-db'
+nimbus_era_files_nclidb_timer_update_name: '{{ nimbus_era_files_nclidb_timer_name }}-update'
+nimbus_era_files_nclidb_timer_enabled: true
+nimbus_era_files_nclidb_timer_user: 'nimbus'
+nimbus_era_files_nclidb_timer_group: 'staff'
+nimbus_era_files_nclidb_timer_frequency: 'daily'
+nimbus_era_files_nclidb_timer_timeout_sec: 1500 # 25 minutes
+nimbus_era_files_nclidb_timer_ionice_class: 'idle'
+nimbus_era_files_nclidb_repo_url: 'https://github.com/status-im/nimbus-eth2'
+nimbus_era_files_nclidb_nix_flake_target: 'ncli_db'
+#FIXME using unstable branch until the feature propagates to stable branch
+nimbus_era_files_nclidb_repo_branch: 'unstable'
+nimbus_era_files_nclidb_result_path: '/var/lib/nimbus-era-files/result'
+nimbus_era_files_nclidb_path: '{{ nimbus_era_files_nclidb_result_path }}/bin/nimbus_ncli_db'
+
 # Mandatory
-#nimbus_era_files_nclidb_path: ~
 #nimbus_era_files_db_path: ~
 #nimbus_era_files_network: ~

--- a/ansible/roles/nimbus-era-files/tasks/linux.yml
+++ b/ansible/roles/nimbus-era-files/tasks/linux.yml
@@ -1,4 +1,36 @@
 ---
+- name: Ensure ncli_db work directory exists
+  file:
+    path: '{{ nimbus_era_files_nclidb_result_path | dirname }}'
+    state: directory
+    owner: '{{ nimbus_era_files_nclidb_timer_user }}'
+    group: '{{ nimbus_era_files_nclidb_timer_group }}'
+    mode: '0755'
+
+- name: Check if ncli_db binary exists
+  stat:
+    path: '{{ nimbus_era_files_nclidb_path }}'
+  register: ncli_db_bin
+
+- name: Create timer for ncli_db update
+  include_role: name=infra-role-systemd-timer
+  vars:
+    systemd_timer_description:       'Update ncli_db executable'
+    systemd_timer_name:              '{{ nimbus_era_files_nclidb_timer_update_name }}'
+    systemd_timer_user:              '{{ nimbus_era_files_nclidb_timer_user }}'
+    systemd_timer_group:             '{{ nimbus_era_files_nclidb_timer_group }}'
+    systemd_timer_ionice_class:      '{{ nimbus_era_files_nclidb_timer_ionice_class }}'
+    systemd_timer_start_on_creation: '{{ not ncli_db_bin.stat.exists }}'
+    systemd_timer_enabled:           '{{ nimbus_era_files_nclidb_timer_enabled }}'
+    systemd_timer_frequency:         '{{ nimbus_era_files_nclidb_timer_frequency }}'
+    systemd_timer_timeout_sec:       '{{ nimbus_era_files_nclidb_timer_timeout_sec }}'
+    systemd_timer_work_dir:          '{{ nimbus_era_files_nclidb_result_path | dirname }}'
+    systemd_timer_script_path:       '/nix/var/nix/profiles/default/bin/nix'
+    systemd_timer_script_args: >-
+      build --no-write-lock-file --refresh
+      --out-link {{ nimbus_era_files_nclidb_result_path }}
+      "git+{{ nimbus_era_files_nclidb_repo_url }}?submodules=1&ref={{ nimbus_era_files_nclidb_repo_branch }}#{{ nimbus_era_files_nclidb_nix_flake_target }}"
+
 - name: Create timer for ERA file updates
   include_role: name=infra-role-systemd-timer
   vars:


### PR DESCRIPTION
The ncli_db is built using Nix.

Referenced issue:
* https://github.com/status-im/infra-nimbus/issues/276