### PR TITLE
nimbus: set explicit quic-port for testing/unstable beacon nodes

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -91,8 +91,10 @@ beacon_node_repo_branch: '{{ node_name_to_branch_map.get(node.branch, node.branc
 beacon_node_history_retention: '{{ "archive" if node.get("public_api") else node.get("history", "prune") }}'
 beacon_node_extra_flags:
   'local-block-value-boost': '{{ (0 if node.get("payload_builder", false) else 10) | int }}'
-  'debug-quic': '{{ node.get("debug_quic", false) | bool }}'
-  'debug-quic-port': '{{ 9100 + node._idx|int + 1 }}'
+
+# QUIC feature not yet available in stable branch.
+beacon_node_quic_enabled: '{{ node.branch in ["testing", "unstable"] }}'
+beacon_node_quic_port: '{{ 9100 + node._idx|int + 1 }}'
 
 beacon_node_doppelganger_detection: true
 beacon_node_suggested_gas_limit: 60000000

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -95,6 +95,11 @@ beacon_node_extra_flags: '{{ node.extra_flags if node.extra_flags is defined els
 beacon_node_cores_per_node: '{{ (ansible_processor_vcpus / nodes_layout[inventory_hostname]|length) | round(0, "ceil") | int }}'
 beacon_node_threads: '{{ (node.branch == "libp2p") | ternary(1, beacon_node_cores_per_node) }}'
 # We map short names to branches to avoid too long service names.
+
+# QUIC feature not yet available in stable branch.
+beacon_node_quic_enabled: '{{ node.branch in ["testing", "unstable"] }}'
+beacon_node_quic_port: '{{ 9100 + node._idx|int + 1 }}'
+
 node_name_to_branch_map:
   libp2p: 'syncv3'
 # Builds
@@ -184,6 +189,7 @@ open_ports_list:
     - { port: '{{ beacon_node_closed_libp2p_ports }}', comment: 'Block Beacon Node Discovery', protocol: 'udp', verdict: 'drop', disabled: '{{ beacon_node_closed_libp2p_ports|trim == "" }}' }
     - { port: '9001-9004',                             comment: 'Beacon Node libp2p',          protocol: 'tcp'                                }
     - { port: '9001-9004',                             comment: 'Beacon Node discovery',       protocol: 'udp'                                }
+    - { port: '9101-9104',                             comment: 'Beacon Node QUIC',            protocol: 'udp'                                }
     - { port: '9201-9204',                             comment: 'Beacon Node Metrics',         ipset: 'hq.metrics',            iifname: 'wg0' }
     - { port: '9301-9304',                             comment: 'Beacon Node REST API',        ipset: '{{ env }}.{{ stage }}', iifname: 'wg0' }
   nimbus-light-client:

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -35,6 +35,10 @@ beacon_node_doppelganger_detection: true
 beacon_node_suggested_gas_limit: 60000000
 beacon_node_payload_builder_enabled: '{{ node.get("payload_builder", false) }}'
 beacon_node_payload_builder_url: 'http://localhost:{{ mev_boost_cont_port }}'
+
+# QUIC feature not yet available in stable branch.
+beacon_node_quic_enabled: '{{ node.branch in ["testing", "unstable"] }}'
+beacon_node_quic_port: '{{ 9100 + node._idx|int + 11 }}'
 # Updates
 beacon_node_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:00:00'
 beacon_node_update_build_nim_flags: '-d:noSignalHandler {{ node.get("nim_flags", "") }}'
@@ -77,7 +81,6 @@ validator_client_network: '{{ beacon_node_network }}'
 validator_client_log_level: 'INFO'
 validator_client_doppelganger_detection: '{{ beacon_node_doppelganger_detection }}'
 validator_client_payload_builder_enabled: '{{ beacon_node_payload_builder_enabled }}'
-validator_client_beacon_node_urls:
 validator_client_beacon_node_urls: ['http://127.0.0.1:{{ beacon_node_rest_port }}']
 
 # Builds
@@ -122,6 +125,7 @@ open_ports_list:
     beacon-node:
       - { port: '9011-9014',   comment: 'Beacon Node libp2p',    protocol: 'tcp'                                    }
       - { port: '9011-9014',   comment: 'Beacon Node discovery', protocol: 'udp'                                    }
+      - { port: '9111-9114',   comment: 'Beacon Node QUIC',      protocol: 'udp'                                    }
       - { port: '9211-9214',   comment: 'Beacon Node Metrics',   ipset: 'hq.metrics',                iifname: 'wg0' }
       - { port: '9311-9314',   comment: 'Beacon Node REST API',  ipset: '{{ env }}.{{ stage }}',     iifname: 'wg0' }
     validator-client:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -34,7 +34,7 @@
 
 - name: infra-role-beacon-node-linux
   src: git@github.com:status-im/infra-role-beacon-node-linux.git
-  version: ed72d93327b2c8706e0909a4bd78ac1c7a18c3f6
+  version: 95cd0c45aacb5537ed96c771310cc2ed2d8564e1
 
 - name: infra-role-beacon-node-windows
   src: git@github.com:status-im/infra-role-beacon-node-windows.git

--- a/ansible/vars/layout/hoodi.yml
+++ b/ansible/vars/layout/hoodi.yml
@@ -11,7 +11,7 @@ nodes_layout:
   'geth-02.ih-eu-mda1.nimbus.hoodi': # 1 each
     - { branch: 'stable',   start:     0, end:    1,  el: 'geth', vc: true  }
     - { branch: 'testing',  start:     1, end:    2,  el: 'geth', vc: false, public_api: true }
-    - { branch: 'unstable', start:     2, end:    3,  el: 'geth', vc: false, debug_quic: true }
+    - { branch: 'unstable', start:     2, end:    3,  el: 'geth', vc: false }
     - { branch: 'libp2p',   start:     3, end:    4,  el: 'geth', vc: false }
 
   'geth-03.ih-eu-mda1.nimbus.hoodi': # 4 each
@@ -48,7 +48,7 @@ nodes_layout:
   'nec-03.ih-eu-mda1.nimbus.hoodi': # 4 each
     - { branch: 'stable',   start: 16664, end: 16668, el: 'nec', vc: false }
     - { branch: 'testing',  start: 16668, end: 16672, el: 'nec', vc: false }
-    - { branch: 'unstable', start: 16672, end: 16676, el: 'nec', vc: true,  debug_quic: true }
+    - { branch: 'unstable', start: 16672, end: 16676, el: 'nec', vc: true  }
     - { branch: 'syncv3',   start: 16676, end: 16680, el: 'nec', vc: false, resync: true }
 
   'nec-04.ih-eu-mda1.nimbus.hoodi': # 1500 each
@@ -91,7 +91,7 @@ nodes_layout:
   'neth-05.ih-eu-mda1.nimbus.hoodi': # 2680 each
     - { branch: 'stable',   start: 39340, end: 42005, el: 'nethermind', vc: false, payload_builder: true }
     - { branch: 'testing',  start: 42005, end: 44670, el: 'nethermind', vc: false, rpc_snooper: true }
-    - { branch: 'unstable', start: 44670, end: 47335, el: 'nethermind', vc: true,  debug_quic: true }
+    - { branch: 'unstable', start: 44670, end: 47335, el: 'nethermind', vc: true  }
     - { branch: 'libp2p',   start: 47335, end: 50000, el: 'nethermind', vc: false }
 
   # MacOS --------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/commit/4a4ac9c1d1a230eaa0ed83fb2ab85acd8df35391 enables QUIC by default on fixed port 9001. Collides with stable's discovery port and crash-looping fleets on mainnet, hoodi and sepolia after the nightly builds.

Older builds reject the quic-port config key, so it is only enabled for branches on 4a4ac9+ builds via beacon_node_quic_branches.