### PR TITLE
all: combine base and extra lists of open ports

### DIFF
--- a/ansible/group_vars/dash.nimbus.yml
+++ b/ansible/group_vars/dash.nimbus.yml
@@ -56,7 +56,8 @@ bootstrap__firewall_nftables: true
 
 # Open Nginx Ports
 open_ports_default_comment: 'ElasticSearch LB'
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   elasticsearch_lb:
     - { port: '{{ es_lb_api_port }}',   ipset: 'logs.nimbus', iifname: 'wg0', comment: 'Elasticsearch LB' }
     - { port: '{{ es_lb_node_port }}',  ipset: 'logs.nimbus', iifname: 'wg0', comment: 'Elasticsearch LB' }

--- a/ansible/group_vars/logs.nimbus.yml
+++ b/ansible/group_vars/logs.nimbus.yml
@@ -53,7 +53,8 @@ bootstrap__firewall_nftables: true
 
 # Open Ports
 open_ports_default_comment: 'ElasticSearch'
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   elasticsearch:
     - { port: '{{ es_api_port  }}',              ipset: 'hq.metrics',  iifname: 'wg0' }
     - { port: '{{ es_api_port  }}',              ipset: 'hq.logs',     iifname: 'wg0' }

--- a/ansible/group_vars/nimbus-bench.eth1.yml
+++ b/ansible/group_vars/nimbus-bench.eth1.yml
@@ -14,7 +14,8 @@ nimbus_eth1_era_dir: '/data/era'
 nimbus_eth1_era1_dir: '/data/era1'
 
 # Open Ports -------------------------------------------------------------------
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   el-node:
     - { port: '{{ nimbus_eth1_listening_port }}', comment: 'Nimbus node listening port', protocol: 'tcp' }
     - { port: '{{ nimbus_eth1_discovery_port }}', comment: 'Nimbus node discovery port', protocol: 'udp' }

--- a/ansible/group_vars/nimbus.eth1.yml
+++ b/ansible/group_vars/nimbus.eth1.yml
@@ -43,7 +43,8 @@ nimbus_eth1_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stag
 bootstrap__firewall_nftables: true
 
 # Open Ports -------------------------------------------------------------------
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   el-node:
     - { comment: 'Nimbus node listening port',     port: '{{ nimbus_eth1_listening_port }}',     protocol: 'tcp'                      }
     - { comment: 'Nimbus node discovery port',     port: '{{ nimbus_eth1_discovery_port }}',     protocol: 'udp'                      }

--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -212,7 +212,8 @@ bootstrap__firewall_nftables: true
 
 # Open Ports -------------------------------------------------------------------
 host_el_type: '{{ ansible_hostname|split("-")|first }}'
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   nginx:
     - { port: 443, comment: 'Nginx' }
   exec-node:

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -171,7 +171,8 @@ bootstrap__firewall_nftables: true
 
 # Open Ports
 host_el_type: '{{ ansible_hostname|split("-")|first }}'
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   nginx:
     - { port: '443', comment: 'Nginx' }
   exec-node:

--- a/ansible/group_vars/nimbus.portal.yml
+++ b/ansible/group_vars/nimbus.portal.yml
@@ -97,7 +97,8 @@ nimbus_eth1_jwt_secret: '{{lookup("vault", "engine-api", field="jwt-token", stag
 bootstrap__firewall_nftables: true
 
 # Open Ports -------------------------------------------------------------------
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
   nimbus-portal-client:
     - { comment: 'Nimbus Portal Client',         port: '{{ nimbus_portal_client_listening_port }}',                                                        protocol: 'udp' }
     - { comment: 'Nimbus Portal Client Metrics', port: '9201-92{{ nimbus_portal_client_host_number_of_public_ips }}', ipset: 'hq.metrics', iifname: 'wg0', protocol: 'tcp' }

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -114,7 +114,8 @@ bootstrap__firewall_nftables: true
 
 # Open Ports
 host_el_type: 'EL node'
-open_ports_list:
+open_ports_list: '{{ open_ports_base | combine(open_ports_extra|default({}), recursive=true) }}'
+open_ports_base:
     nginx:
       - { port: 443,           comment: 'Nginx' }
     exec-node:

--- a/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-01.aws-eu-central-1a.nimbus.mainnet.yml
@@ -15,7 +15,7 @@ beacon_node_metrics_port: 9200
 beacon_node_rest_port: 9300
 
 # Open Ports
-open_ports_list:
+open_ports_extra:
   nginx:
     - { port: '443', comment: 'Nginx' }
   beacon-node:

--- a/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
+++ b/ansible/host_vars/bootstrap-02.aws-eu-central-1a.nimbus.mainnet.yml
@@ -15,7 +15,7 @@ beacon_node_metrics_port: 9200
 beacon_node_rest_port: 9300
 
 # Open Ports
-open_ports_list:
+open_ports_extra:
   nginx:
     - { port: '443', comment: 'Nginx' }
   beacon-node:

--- a/ansible/host_vars/geth-05.ih-eu-mda1.nimbus.hoodi.yml
+++ b/ansible/host_vars/geth-05.ih-eu-mda1.nimbus.hoodi.yml
@@ -16,6 +16,6 @@ commit_boost_late_in_slot_time_ms: 2500
 
 beacon_node_payload_builder_url: 'http://localhost:{{ commit_boost_cont_port }}'
 
-open_ports_list:
+open_ports_extra:
   commit-boost:
     - { port: '{{ commit_boost_cont_metrics_port }}', comment: 'Commit Boost metrics', ipset: 'hq.metrics', iifname: 'wg0' }

--- a/ansible/vars/portal-bridge.yml
+++ b/ansible/vars/portal-bridge.yml
@@ -10,7 +10,7 @@ nimbus_portal_client_metrics_port:     '{{ portal_bridge_portal_client_metrics_p
 nimbus_portal_client_listening_port:   '{{ portal_bridge_portal_client_listening_port }}'
 
 # Open Ports -------------------------------------------------------------------
-open_ports_list:
+open_ports_extra:
   nimbus-portal:
     - { comment: 'Nimbus Portal',          port: '{{ portal_bridge_portal_client_listening_port }}',                                      protocol: 'udp' }
     - { comment: 'Nimbus Portal Metrics',  port: '{{ portal_bridge_portal_client_metrics_port }}',   ipset: 'hq.metrics', iifname: 'wg0', protocol: 'tcp' }


### PR DESCRIPTION
Otherwise `host_vars` have higher priority than `group_vars` and they overwrite the list resulting in missing rules on hosts.

https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence

Result:

<img width="1226" height="391" alt="image" src="https://github.com/user-attachments/assets/fc33c9ff-93e4-44d3-8bc9-369cfd15e7f4" />