### PR TITLE
systemd-timer: delay update timers for BN,VC and ncli_db

### DIFF
--- a/ansible/group_vars/nimbus.hoodi.yml
+++ b/ansible/group_vars/nimbus.hoodi.yml
@@ -173,7 +173,7 @@ validator_client_payload_builder_enabled: '{{ beacon_node_payload_builder_enable
 validator_client_beacon_node_urls: ['http://127.0.0.1:{{ beacon_node_rest_port }}']
 # Builds
 validator_client_repo_branch: '{{ beacon_node_repo_branch }}'
-validator_client_update_frequency: 'daily'
+validator_client_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:20:00'
 # Ports
 validator_client_metrics_port:    '{{ 8108 + node._idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + node._idx|int + 1 }}'
@@ -194,6 +194,7 @@ dist_validators_repo_ssh_key: '{{lookup("vault", "dist-validators/deploy-key", f
 
 # ERA files generation ---------------------------------------------------------
 nimbus_era_files_timer_enabled: true
+nimbus_era_files_nclidb_timer_frequency: '*-*-* 00:40:00'
 nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/data/db'

--- a/ansible/group_vars/nimbus.mainnet.yml
+++ b/ansible/group_vars/nimbus.mainnet.yml
@@ -159,6 +159,7 @@ beacon_node_nix_flake_target: "{{ 'beacon_node_gcc11' if node.branch == 'unstabl
 
 # ERA files geneartion.
 nimbus_era_files_timer_enabled: "{{ not inventory_hostname.startswith('bootstrap') }}"
+nimbus_era_files_nclidb_timer_frequency: '*-*-* 00:40:00'
 nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 # FIXME: Not pretty, since hardcoded, but the simplest way to do it right now.

--- a/ansible/group_vars/nimbus.sepolia.yml
+++ b/ansible/group_vars/nimbus.sepolia.yml
@@ -84,7 +84,7 @@ validator_client_beacon_node_urls: ['http://127.0.0.1:{{ beacon_node_rest_port }
 
 # Builds
 validator_client_repo_branch: '{{ beacon_node_repo_branch }}'
-validator_client_update_frequency: 'daily'
+validator_client_update_frequency: '*-*-* {{ "%02d" | format(node._idx * 2) }}:20:00'
 # Ports
 validator_client_metrics_port:    '{{ 8108 + node._idx|int + 1 }}'
 validator_client_keymanager_port: '{{ 5052 + node._idx|int + 1 }}'
@@ -103,6 +103,7 @@ dist_validators_repo_ssh_key: '{{lookup("vault", "dist-validators/deploy-key", f
 
 # ERA files geneartion ---------------------------------------------------------
 nimbus_era_files_timer_enabled: true
+nimbus_era_files_nclidb_timer_frequency: '*-*-* 00:40:00'
 nimbus_era_files_timer_path: '{{ era_files_path }}'
 nimbus_era_files_network: '{{ beacon_node_network }}'
 nimbus_era_files_db_path: '/data/beacon-node-{{ beacon_node_network }}-unstable/data/db'


### PR DESCRIPTION
Fixes random failures caused by timer timeouts since a single the nix build locks the sqlite db for that user(nimbus).

```bash
Aug 21 00:00:32 neth-04.ih-eu-mda1.nimbus.hoodi nix[2383287]: error (ignored): SQLite database '/home/nimbus/.cache/nix/eval-cache-v6/49e8b0fdfb05c80371ec756fbd1f688e9d07fa90e4dd5d29bf1a9803626e4bf1.sqlite' is busy
Aug 21 00:00:32 neth-04.ih-eu-mda1.nimbus.hoodi nix[2383287]: copying path '/nix/store/0h5x2bzrz1rxin1gb66vp81rjsrm278x-source' from 'https://nix-cache.status.im'...
Aug 21 00:25:00 neth-04.ih-eu-mda1.nimbus.hoodi systemd[1]: nimbus-era-files-ncli-db-update.service: start operation timed out. Terminating.
```